### PR TITLE
Feature/yaml concat support

### DIFF
--- a/confs/yaml_interface.py
+++ b/confs/yaml_interface.py
@@ -341,7 +341,7 @@ class YAML:
                 yaml_file_list.append(yaml_value)
 
             print(self.concat_yaml(yaml_file_list=yaml_file_list,
-                                   yaml_file_out=None, ignore_missing=True, fail_nonvalid=False))
+                                   yaml_file_out=None, ignore_missing=True))
 
         # print(yaml_dict)
 

--- a/confs/yaml_interface.py
+++ b/confs/yaml_interface.py
@@ -124,7 +124,7 @@ class YAML:
         for attr in attr_dict.keys():
             attr_list.append(attr)
             value = parser_interface.dict_key_value(
-                dict_in=yaml_dict, key=attr, no_split=True
+                dict_in=attr_dict, key=attr, no_split=True
             )
             yaml_obj = parser_interface.object_setattr(
                 object_in=yaml_obj, key=attr, value=value

--- a/confs/yaml_interface.py
+++ b/confs/yaml_interface.py
@@ -285,10 +285,16 @@ class YAML:
         # determine whether a given file is a YAML-formatted file and
         # whether the respective YAML-formatted file exists; proceed
         # acccordingly.
-        for yaml_attr in yaml_dict:
-            print(yaml_attr)
+        for attr_key in yaml_dict:
 
-        print('here')
+            # Collect the attribute corresponding to the respective
+            # attribute; proceed accordingly.
+            attr_value = parser_interface.dict_key_value(
+                dict_in=yaml_dict, key=attr_key, no_split=True)
+            is_yaml = self.check_yaml(attr_value=attr_value)
+
+            print(attr_key, attr_value)
+
         quit()
 
     def read_yaml(self, yaml_file: str, return_obj: bool = False) -> Union[dict, object]:
@@ -345,22 +351,22 @@ class YAML:
         # Open and read the contents of the specified YAML-formatted
         # file path.
         with open(yaml_file, "r", encoding="utf-8") as stream:
-            yaml_dict = yaml.load(stream, Loader=YAMLLoader)
+            yaml_dict=yaml.load(stream, Loader=YAMLLoader)
 
         # Define the Python data type to be returned; proceed
         # accordingly.
-        yaml_return = None
+        yaml_return=None
         if return_obj:
-            (attr_list, yaml_obj) = ([], parser_interface.object_define())
+            (attr_list, yaml_obj)=([], parser_interface.object_define())
             for key in yaml_dict.keys():
                 attr_list.append(key)
-                value = parser_interface.dict_key_value(
+                value=parser_interface.dict_key_value(
                     dict_in=yaml_dict, key=key, no_split=True
                 )
-                yaml_obj = parser_interface.object_setattr(
+                yaml_obj=parser_interface.object_setattr(
                     object_in=yaml_obj, key=key, value=value
                 )
-            yaml_return = yaml_obj
+            yaml_return=yaml_obj
 
         if not return_obj:
 

--- a/confs/yaml_interface.py
+++ b/confs/yaml_interface.py
@@ -293,7 +293,7 @@ class YAML:
                 dict_in=yaml_dict, key=attr_key, no_split=True)
             is_yaml = self.check_yaml(attr_value=attr_value)
 
-            print(attr_key, attr_value)
+            print(attr_key, attr_value, is_yaml)
 
         quit()
 
@@ -351,7 +351,7 @@ class YAML:
         # Open and read the contents of the specified YAML-formatted
         # file path.
         with open(yaml_file, "r", encoding="utf-8") as stream:
-            yaml_dict=yaml.load(stream, Loader=YAMLLoader)
+            yaml_dict = yaml.load(stream, Loader=YAMLLoader)
 
         # Define the Python data type to be returned; proceed
         # accordingly.

--- a/confs/yaml_interface.py
+++ b/confs/yaml_interface.py
@@ -266,17 +266,26 @@ class YAML:
 
         # Write the resulting composite Python dictionary to
         # YAML-formatted file to contain the concatenated attributes.
+        self.write_yaml(yaml_file=yaml_file_out, in_dict=yaml_dict_concat)
 
-        print(yaml_dict_concat)
+    def read_concat_yaml(self, yaml_file: str, return_obj: bool = False) -> Union[dict, object]:
+        """ """
+
+        # Define the YAML library loader type.
+        YAMLLoader.add_implicit_resolver(
+            "!ENV", YAMLLoader.envvar_matcher, None)
+        YAMLLoader.add_constructor("!ENV", YAMLLoader.envvar_constructor)
+
+        # Open and read the contents of the specified YAML-formatted
+        # file path.
+        with open(yaml_file, "r", encoding="utf-8") as stream:
+            yaml_dict = yaml.load(stream, Loader=YAMLLoader)
+
+        print('here')
+        print(yaml_dict)
         quit()
 
-        return yaml_dict_concat
-
-        # self.write_yaml(yaml_file=yaml_file_out, in_dict=yaml_dict_concat)
-
-    def read_yaml(
-            self, yaml_file: str, return_obj: bool = False,
-            concat_yamls: bool = False) -> Union[dict, object]:
+    def read_yaml(self, yaml_file: str, return_obj: bool = False) -> Union[dict, object]:
         """
         Description
         -----------
@@ -331,34 +340,6 @@ class YAML:
         # file path.
         with open(yaml_file, "r", encoding="utf-8") as stream:
             yaml_dict = yaml.load(stream, Loader=YAMLLoader)
-
-        # If the concatenating the attributes provided in the
-        # YAML-formatted file, proceed accordingly.
-        if concat_yamls:
-
-            concat_yaml_dict = {}
-            yaml_file_list = []
-            for yaml_key in yaml_dict:
-
-                # Collect YAML attribute value; check whether the
-                # respective attribute is an existent YAML-formatted
-                # file; proceed accordingly.
-                attr_value = parser_interface.dict_key_value(
-                    dict_in=yaml_dict, key=yaml_key, no_split=True)
-                if self.check_yaml(attr_value=attr_value):
-
-                    # Check that the YAML-formatted file exists;
-                    # proceed accordingly.
-                    if fileio_interface.fileexist(path=attr_value):
-                        yaml_file_list.append(attr_value)
-
-                # yaml_file_list.append(yaml_value
-                self.concat_yaml(yaml_file_list=yaml_file_list,
-                                 yaml_file_out=None, ignore_missing=True)
-
-        # print(yaml_dict)
-
-        quit()
 
         # Define the Python data type to be returned; proceed
         # accordingly.

--- a/confs/yaml_interface.py
+++ b/confs/yaml_interface.py
@@ -333,7 +333,7 @@ class YAML:
         # YAML-formatted file, proceed accordingly.
         if concat_yamls:
 
-            yaml_dict = self.concat_yaml(yaml_file_list=yaml_dict.keys(),
+            yaml_dict = self.concat_yaml(yaml_file_list=yaml_dict.values(),
                                          yaml_file_out=None, ignore_missing=True)
 
         print(yaml_dict)

--- a/confs/yaml_interface.py
+++ b/confs/yaml_interface.py
@@ -340,7 +340,7 @@ class YAML:
                     dict_in=yaml_dict, key=yaml_key, no_split=True)
 
             print(self.concat_yaml(yaml_file_list=yaml_file_list,
-                                   yaml_file_out=None, ignore_missing=True, fail_invalid=False))
+                                   yaml_file_out=None, ignore_missing=True, fail_nonvalid=False))
 
         # print(yaml_dict)
 

--- a/confs/yaml_interface.py
+++ b/confs/yaml_interface.py
@@ -344,7 +344,10 @@ class YAML:
                     dict_in=yaml_dict, key=yaml_key, no_split=True)
 
                 if self.check_yaml(attr_value=value):
-                    print(yaml_key, value)
+
+                    if fileio_interface.fileexist(path=value):
+
+                        print(yaml_key, value)
 
         quit()
 

--- a/confs/yaml_interface.py
+++ b/confs/yaml_interface.py
@@ -266,7 +266,10 @@ class YAML:
 
         # Write the resulting composite Python dictionary to
         # YAML-formatted file to contain the concatenated attributes.
-        self.write_yaml(yaml_file=yaml_file_out, in_dict=yaml_dict_concat)
+
+        return yaml_dict_concat
+
+        #self.write_yaml(yaml_file=yaml_file_out, in_dict=yaml_dict_concat)
 
     def read_yaml(
             self, yaml_file: str, return_obj: bool = False,
@@ -330,24 +333,10 @@ class YAML:
         # YAML-formatted file, proceed accordingly.
         if concat_yamls:
 
-            # Initialize the Python dictionary to contain the
-            # concatenated YAML attributes; build the Python
-            # dictionary accordingly.
-            yaml_dict_concat = {}
+            yaml_dict = self.concat_yaml(yaml_file_list=yaml_dict.keys(),
+                                         yaml_file_out=None, ignore_missing=True)
 
-            for yaml_key in yaml_dict:
-
-                # Check if the respective YAML attribute value is an
-                # existing YAML-formatted file path; proceed
-                # accordingly.
-                value = parser_interface.dict_key_value(
-                    dict_in=yaml_dict, key=yaml_key, no_split=True)
-
-                if self.check_yaml(attr_value=value):
-
-                    if fileio_interface.fileexist(path=value):
-
-                        print(yaml_key, value)
+        print(yaml_dict)
 
         quit()
 

--- a/confs/yaml_interface.py
+++ b/confs/yaml_interface.py
@@ -333,7 +333,7 @@ class YAML:
         # YAML-formatted file, proceed accordingly.
         if concat_yamls:
 
-            yaml_file_list = ()
+            yaml_file_list = []
             for yaml_key in yaml_dict:
 
                 yaml_value = parser_interface.dict_key_value(

--- a/confs/yaml_interface.py
+++ b/confs/yaml_interface.py
@@ -335,11 +335,14 @@ class YAML:
 
             yaml_file_list = ()
             for yaml_key in yaml_dict:
-                yaml_file_list.append(parser_interface.dict_key_value(
-                    dict_in=yaml_dict, key=yaml_key, no_split=True))
 
-            print(self.concat_yaml(yaml_file_list=yaml_file_list,
-                                   yaml_file_out=None, ignore_missing=True))
+                yaml_value = parser_interface.dict_key_value(
+                    dict_in=yaml_dict, key=yaml_key, no_split=True)
+
+                print(yaml_value)
+
+            # print(self.concat_yaml(yaml_file_list=yaml_file_list,
+            #                       yaml_file_out=None, ignore_missing=True))
 
         # print(yaml_dict)
 

--- a/confs/yaml_interface.py
+++ b/confs/yaml_interface.py
@@ -333,12 +333,23 @@ class YAML:
         # YAML-formatted file, proceed accordingly.
         if concat_yamls:
 
+            concat_yaml_dict = {}
             yaml_file_list = []
             for yaml_key in yaml_dict:
 
-                yaml_value = parser_interface.dict_key_value(
+                # Collect YAML attribute value; check whether the
+                # respective attribute is an existent YAML-formatted
+                # file; proceed accordingly.
+                attr_value = parser_interface.dict_key_value(
                     dict_in=yaml_dict, key=yaml_key, no_split=True)
-                yaml_file_list.append(yaml_value)
+                if self.check_yaml(attr_value=attr_value):
+
+                    # Check that the YAML-formatted file exists;
+                    # proceed accordingly.
+                    if fileio_interface.fileexist(path=attr_value):
+                        yaml_file_list.append(attr_value)
+
+                # yaml_file_list.append(yaml_value)
 
             print(self.concat_yaml(yaml_file_list=yaml_file_list,
                                    yaml_file_out=None, ignore_missing=True))

--- a/confs/yaml_interface.py
+++ b/confs/yaml_interface.py
@@ -338,6 +338,7 @@ class YAML:
 
                 yaml_value = parser_interface.dict_key_value(
                     dict_in=yaml_dict, key=yaml_key, no_split=True)
+                yaml_file_list.append(yaml_value)
 
             print(self.concat_yaml(yaml_file_list=yaml_file_list,
                                    yaml_file_out=None, ignore_missing=True, fail_nonvalid=False))

--- a/confs/yaml_interface.py
+++ b/confs/yaml_interface.py
@@ -279,21 +279,27 @@ class YAML:
         # Open and read the contents of the specified YAML-formatted
         # file path.
         with open(yaml_file, "r", encoding="utf-8") as stream:
-            yaml_dict = yaml.load(stream, Loader=YAMLLoader)
+            yaml_full_dict = yaml.load(stream, Loader=YAMLLoader)
 
         # For each attribute within the parsed YAML-formatted file,
         # determine whether a given file is a YAML-formatted file and
         # whether the respective YAML-formatted file exists; proceed
         # acccordingly.
-        for attr_key in yaml_dict:
+        yaml_dict_concat = {}
+        for attr_key in yaml_full_dict:
 
             # Collect the attribute corresponding to the respective
             # attribute; proceed accordingly.
             attr_value = parser_interface.dict_key_value(
-                dict_in=yaml_dict, key=attr_key, no_split=True)
+                dict_in=yaml_full_dict, key=attr_key, no_split=True)
             is_yaml = self.check_yaml(attr_value=attr_value)
 
-            print(attr_key, attr_value, is_yaml)
+            # If the respective attribute value is a YAML-formatted
+            # file, check that it exists and proceed accordingly.
+            if is_yaml:
+                if fileio_interface.fileexist(path=attr_value):
+                    yaml_dict = self.read_yaml(yaml_file=attr_value)
+                    print(yaml_dict)
 
         quit()
 
@@ -355,18 +361,18 @@ class YAML:
 
         # Define the Python data type to be returned; proceed
         # accordingly.
-        yaml_return=None
+        yaml_return = None
         if return_obj:
-            (attr_list, yaml_obj)=([], parser_interface.object_define())
+            (attr_list, yaml_obj) = ([], parser_interface.object_define())
             for key in yaml_dict.keys():
                 attr_list.append(key)
-                value=parser_interface.dict_key_value(
+                value = parser_interface.dict_key_value(
                     dict_in=yaml_dict, key=key, no_split=True
                 )
-                yaml_obj=parser_interface.object_setattr(
+                yaml_obj = parser_interface.object_setattr(
                     object_in=yaml_obj, key=key, value=value
                 )
-            yaml_return=yaml_obj
+            yaml_return = yaml_obj
 
         if not return_obj:
 

--- a/confs/yaml_interface.py
+++ b/confs/yaml_interface.py
@@ -281,8 +281,14 @@ class YAML:
         with open(yaml_file, "r", encoding="utf-8") as stream:
             yaml_dict = yaml.load(stream, Loader=YAMLLoader)
 
+        # For each attribute within the parsed YAML-formatted file,
+        # determine whether a given file is a YAML-formatted file and
+        # whether the respective YAML-formatted file exists; proceed
+        # acccordingly.
+        for yaml_attr in yaml_dict:
+            print(yaml_attr)
+
         print('here')
-        print(yaml_dict)
         quit()
 
     def read_yaml(self, yaml_file: str, return_obj: bool = False) -> Union[dict, object]:

--- a/confs/yaml_interface.py
+++ b/confs/yaml_interface.py
@@ -269,8 +269,8 @@ class YAML:
         self.write_yaml(yaml_file=yaml_file_out, in_dict=yaml_dict_concat)
 
     def read_yaml(
-            self, yaml_file: str, return_obj: bool = False, concat: bool = False,
-    ) -> Union[dict, object]:
+            self, yaml_file: str, return_obj: bool = False,
+            concat_yamls: bool = False) -> Union[dict, object]:
         """
         Description
         -----------
@@ -328,7 +328,7 @@ class YAML:
 
         print(yaml_dict)
         quit()
-            
+
         # Define the Python data type to be returned; proceed
         # accordingly.
         yaml_return = None

--- a/confs/yaml_interface.py
+++ b/confs/yaml_interface.py
@@ -326,7 +326,9 @@ class YAML:
         with open(yaml_file, "r", encoding="utf-8") as stream:
             yaml_dict = yaml.load(stream, Loader=YAMLLoader)
 
-        print(yaml_dict)
+        for yaml_key in yaml_dict:
+            print(yaml_key)
+
         quit()
 
         # Define the Python data type to be returned; proceed

--- a/confs/yaml_interface.py
+++ b/confs/yaml_interface.py
@@ -338,10 +338,10 @@ class YAML:
                 yaml_file_list.append(parser_interface.dict_key_value(
                     dict_in=yaml_dict, key=yaml, no_split=True)
 
-            yaml_dict=self.concat_yaml(yaml_file_list=yaml_file_list,
-                                         yaml_file_out=None, ignore_missing=True)
+            print(self.concat_yaml(yaml_file_list=yaml_file_list,
+                                   yaml_file_out=None, ignore_missing=True))
 
-        print(yaml_dict)
+        # print(yaml_dict)
 
         quit()
 
@@ -352,7 +352,7 @@ class YAML:
             (attr_list, yaml_obj)=([], parser_interface.object_define())
             for key in yaml_dict.keys():
                 attr_list.append(key)
-                value = parser_interface.dict_key_value(
+                value=parser_interface.dict_key_value(
                     dict_in=yaml_dict, key=key, no_split=True
                 )
                 yaml_obj = parser_interface.object_setattr(

--- a/confs/yaml_interface.py
+++ b/confs/yaml_interface.py
@@ -117,6 +117,21 @@ class YAML:
         # Define the base-class attributes.
         self.logger = Logger()
 
+    def __yaml_obj__(self, attr_dict: dict) -> object:
+        """ """
+
+        (attr_list, yaml_obj) = ([], parser_interface.object_define())
+        for attr in attr_dict.keys():
+            attr_list.append(attr)
+            value = parser_interface.dict_key_value(
+                dict_in=yaml_dict, key=attr, no_split=True
+            )
+            yaml_obj = parser_interface.object_setattr(
+                object_in=yaml_obj, key=attr, value=value
+            )
+
+        return yaml_obj
+
     def check_yaml(self, attr_value: str) -> bool:
         """
         Description
@@ -311,11 +326,11 @@ class YAML:
             if not is_yaml:
                 yaml_dict_concat[attr_key] = attr_value
 
-        for key in yaml_dict_concat['fetch']:
-            print(key, parser_interface.dict_key_value(
-                dict_in=yaml_dict_concat['fetch'], key=key, no_split=True))
+        if return_obj:
 
-        # print(yaml_dict_concat['fetch'])
+            yaml_return = self.__yaml_obj__(attr_dict=yaml_dict_concat)
+
+            print(yaml_return)
 
         quit()
 

--- a/confs/yaml_interface.py
+++ b/confs/yaml_interface.py
@@ -326,8 +326,24 @@ class YAML:
         with open(yaml_file, "r", encoding="utf-8") as stream:
             yaml_dict = yaml.load(stream, Loader=YAMLLoader)
 
-        for yaml_key in yaml_dict:
-            print(yaml_key)
+        # If the concatenating the attributes provided in the
+        # YAML-formatted file, proceed accordingly.
+        if concat_yamls:
+
+            # Initialize the Python dictionary to contain the
+            # concatenated YAML attributes; build the Python
+            # dictionary accordingly.
+            yaml_dict_concat = {}
+
+            for yaml_key in yaml_dict:
+
+                # Check if the respective YAML attribute value is an
+                # existing YAML-formatted file path; proceed
+                # accordingly.
+                value = parser_interface.dict_key_value(
+                    dict_in=yaml_dict, key=yaml_key, no_split=True)
+
+                print(value)
 
         quit()
 

--- a/confs/yaml_interface.py
+++ b/confs/yaml_interface.py
@@ -336,7 +336,7 @@ class YAML:
             yaml_file_list = ()
             for yaml in yaml_dict:
                 yaml_file_list.append(parser_interface.dict_key_value(
-                    dict_in=yaml_dict, key=yaml, no_split=True)
+                    dict_in=yaml_dict, key=yaml, no_split=True))
 
             print(self.concat_yaml(yaml_file_list=yaml_file_list,
                                    yaml_file_out=None, ignore_missing=True))
@@ -347,7 +347,7 @@ class YAML:
 
         # Define the Python data type to be returned; proceed
         # accordingly.
-        yaml_return=None
+        yaml_return = None
         if return_obj:
             (attr_list, yaml_obj)=([], parser_interface.object_define())
             for key in yaml_dict.keys():

--- a/confs/yaml_interface.py
+++ b/confs/yaml_interface.py
@@ -310,8 +310,9 @@ class YAML:
         # YAML-formatted file to contain the concatenated attributes.
         self.write_yaml(yaml_file=yaml_file_out, in_dict=yaml_dict_concat)
 
-    def read_concat_yaml(self, yaml_file: str,
-                         return_obj: bool = False) -> Union[dict, object]:
+    def read_concat_yaml(
+        self, yaml_file: str, return_obj: bool = False
+    ) -> Union[dict, object]:
         """
         Description
         -----------
@@ -361,8 +362,7 @@ class YAML:
         """
 
         # Define the YAML library loader type.
-        YAMLLoader.add_implicit_resolver(
-            "!ENV", YAMLLoader.envvar_matcher, None)
+        YAMLLoader.add_implicit_resolver("!ENV", YAMLLoader.envvar_matcher, None)
         YAMLLoader.add_constructor("!ENV", YAMLLoader.envvar_constructor)
 
         # Open and read the contents of the specified YAML-formatted
@@ -380,7 +380,8 @@ class YAML:
             # Collect the attribute corresponding to the respective
             # attribute; proceed accordingly.
             attr_value = parser_interface.dict_key_value(
-                dict_in=yaml_full_dict, key=attr_key, no_split=True)
+                dict_in=yaml_full_dict, key=attr_key, no_split=True
+            )
             is_yaml = self.check_yaml(attr_value=attr_value)
 
             # If the respective attribute value is a YAML-formatted
@@ -391,8 +392,12 @@ class YAML:
                     yaml_dict = self.read_yaml(yaml_file=attr_value)
 
                     yaml_dict_concat.update(
-                        dict(parser_interface.dict_merge(
-                            dict1=yaml_dict_concat, dict2=yaml_dict)))
+                        dict(
+                            parser_interface.dict_merge(
+                                dict1=yaml_dict_concat, dict2=yaml_dict
+                            )
+                        )
+                    )
 
                 if not exist:
                     yaml_dict_concat[attr_key] = attr_value
@@ -412,7 +417,9 @@ class YAML:
 
         return yaml_return
 
-    def read_yaml(self, yaml_file: str, return_obj: bool = False) -> Union[dict, object]:
+    def read_yaml(
+        self, yaml_file: str, return_obj: bool = False
+    ) -> Union[dict, object]:
         """
         Description
         -----------
@@ -459,8 +466,7 @@ class YAML:
         """
 
         # Define the YAML library loader type.
-        YAMLLoader.add_implicit_resolver(
-            "!ENV", YAMLLoader.envvar_matcher, None)
+        YAMLLoader.add_implicit_resolver("!ENV", YAMLLoader.envvar_matcher, None)
         YAMLLoader.add_constructor("!ENV", YAMLLoader.envvar_constructor)
 
         # Open and read the contents of the specified YAML-formatted

--- a/confs/yaml_interface.py
+++ b/confs/yaml_interface.py
@@ -297,9 +297,21 @@ class YAML:
             # If the respective attribute value is a YAML-formatted
             # file, check that it exists and proceed accordingly.
             if is_yaml:
-                if fileio_interface.fileexist(path=attr_value):
+                exist = fileio_interface.fileexist(path=attr_value)
+                if exist:
                     yaml_dict = self.read_yaml(yaml_file=attr_value)
-                    print(yaml_dict)
+
+                    yaml_dict_concat.update(
+                        dict(parser_interface.dict_merge(
+                            dict1=yaml_dict_concat, dict2=yaml_dict)))
+
+                if not exist:
+                    yaml_dict_concat[attr_key] = attr_value
+
+            if not is_yaml:
+                yaml_dict_concat[attr_key] = attr_value
+
+        print(yaml_dict_concat)
 
         quit()
 

--- a/confs/yaml_interface.py
+++ b/confs/yaml_interface.py
@@ -352,11 +352,9 @@ class YAML:
                     if fileio_interface.fileexist(path=attr_value):
                         yaml_file_list.append(attr_value)
 
-                # yaml_file_list.append(yaml_value)
-            print(yaml_file_list)
-
-            # print(self.concat_yaml(yaml_file_list=yaml_file_list,
-            #                       yaml_file_out=None, ignore_missing=True))
+                # yaml_file_list.append(yaml_value
+                self.concat_yaml(yaml_file_list=yaml_file_list,
+                                 yaml_file_out=None, ignore_missing=True)
 
         # print(yaml_dict)
 

--- a/confs/yaml_interface.py
+++ b/confs/yaml_interface.py
@@ -350,9 +350,10 @@ class YAML:
                         yaml_file_list.append(attr_value)
 
                 # yaml_file_list.append(yaml_value)
+            print(yaml_file_list)
 
-            print(self.concat_yaml(yaml_file_list=yaml_file_list,
-                                   yaml_file_out=None, ignore_missing=True))
+            # print(self.concat_yaml(yaml_file_list=yaml_file_list,
+            #                       yaml_file_out=None, ignore_missing=True))
 
         # print(yaml_dict)
 

--- a/confs/yaml_interface.py
+++ b/confs/yaml_interface.py
@@ -269,7 +269,7 @@ class YAML:
 
         return yaml_dict_concat
 
-        #self.write_yaml(yaml_file=yaml_file_out, in_dict=yaml_dict_concat)
+        # self.write_yaml(yaml_file=yaml_file_out, in_dict=yaml_dict_concat)
 
     def read_yaml(
             self, yaml_file: str, return_obj: bool = False,
@@ -333,7 +333,12 @@ class YAML:
         # YAML-formatted file, proceed accordingly.
         if concat_yamls:
 
-            yaml_dict = self.concat_yaml(yaml_file_list=yaml_dict.values(),
+            yaml_file_list = ()
+            for yaml in yaml_dict:
+                yaml_file_list.append(parser_interface.dict_key_value(
+                    dict_in=yaml_dict, key=yaml, no_split=True)
+
+            yaml_dict=self.concat_yaml(yaml_file_list=yaml_file_list,
                                          yaml_file_out=None, ignore_missing=True)
 
         print(yaml_dict)
@@ -342,9 +347,9 @@ class YAML:
 
         # Define the Python data type to be returned; proceed
         # accordingly.
-        yaml_return = None
+        yaml_return=None
         if return_obj:
-            (attr_list, yaml_obj) = ([], parser_interface.object_define())
+            (attr_list, yaml_obj)=([], parser_interface.object_define())
             for key in yaml_dict.keys():
                 attr_list.append(key)
                 value = parser_interface.dict_key_value(

--- a/confs/yaml_interface.py
+++ b/confs/yaml_interface.py
@@ -343,7 +343,8 @@ class YAML:
                 value = parser_interface.dict_key_value(
                     dict_in=yaml_dict, key=yaml_key, no_split=True)
 
-                print(value)
+                if self.check_yaml(attr_value=value):
+                    print(yaml_key, value)
 
         quit()
 

--- a/confs/yaml_interface.py
+++ b/confs/yaml_interface.py
@@ -334,9 +334,9 @@ class YAML:
         if concat_yamls:
 
             yaml_file_list = ()
-            for yaml in yaml_dict:
+            for yaml_key in yaml_dict:
                 yaml_file_list.append(parser_interface.dict_key_value(
-                    dict_in=yaml_dict, key=yaml, no_split=True))
+                    dict_in=yaml_dict, key=yaml_key, no_split=True))
 
             print(self.concat_yaml(yaml_file_list=yaml_file_list,
                                    yaml_file_out=None, ignore_missing=True))
@@ -349,10 +349,10 @@ class YAML:
         # accordingly.
         yaml_return = None
         if return_obj:
-            (attr_list, yaml_obj)=([], parser_interface.object_define())
+            (attr_list, yaml_obj) = ([], parser_interface.object_define())
             for key in yaml_dict.keys():
                 attr_list.append(key)
-                value=parser_interface.dict_key_value(
+                value = parser_interface.dict_key_value(
                     dict_in=yaml_dict, key=key, no_split=True
                 )
                 yaml_obj = parser_interface.object_setattr(

--- a/confs/yaml_interface.py
+++ b/confs/yaml_interface.py
@@ -118,14 +118,41 @@ class YAML:
         self.logger = Logger()
 
     def __yaml_obj__(self, attr_dict: dict) -> object:
-        """ """
+        """
+        Description
+        -----------
 
+        This method parses a Python dictionary containing attributes
+        collected from a YAML-formatted file and returned as a Python
+        object.
+
+        Parameters
+        ----------
+
+        attr_dict: dict
+
+            A Python dictionary containing the attributes collected
+            from a YAML-formatted file.
+
+        Returns
+        -------
+
+        yaml_obj: object
+
+            A Python object containing the attributes collected from
+            the Python dictionary provided upon entry.
+
+        """
+
+        # Collect the attributes within the Python dictionary provided
+        # upon entry and build a Python object.
         (attr_list, yaml_obj) = ([], parser_interface.object_define())
         for attr in attr_dict.keys():
             attr_list.append(attr)
             value = parser_interface.dict_key_value(
                 dict_in=attr_dict, key=attr, no_split=True
             )
+
             yaml_obj = parser_interface.object_setattr(
                 object_in=yaml_obj, key=attr, value=value
             )
@@ -283,8 +310,55 @@ class YAML:
         # YAML-formatted file to contain the concatenated attributes.
         self.write_yaml(yaml_file=yaml_file_out, in_dict=yaml_dict_concat)
 
-    def read_concat_yaml(self, yaml_file: str, return_obj: bool = False) -> Union[dict, object]:
-        """ """
+    def read_concat_yaml(self, yaml_file: str,
+                         return_obj: bool = False) -> Union[dict, object]:
+        """
+        Description
+        -----------
+
+        This method ingests a YAML Ain't Markup Language (e.g., YAML)
+        formatted file and returns a Python dictionary containing the
+        concatenated attributes of the file; this method is useful for
+        parsing YAML-formatted files with embedded YAML-formatted file
+        directives (e.g., the YAML-formatted file contains paths to
+        external YAML-formatted files to also be parsed).
+
+        Parameters
+        ----------
+
+        yaml_file: str
+
+            A Python string containing the full-path to the
+            YAML-formatted file to be parsed.
+
+        Keywords
+        --------
+
+        return_obj: bool, optional
+
+            A Python boolean valued variable specifying whether to
+            return a Python object containing the YAML-formatted file
+            contents; in this instance a Python dictionary will be
+            defined using the contents of the YAML-formatted file and
+            then the Python object will be constructed; if True,
+            yaml_obj is returned instead of yaml_dict.
+
+        Returns
+        -------
+
+        yaml_dict: dict
+
+            A Python dictionary containing all attributes ingested
+            from the YAML-formatted file; returned if return_obj is
+            False upon entry.
+
+        yaml_obj: object
+
+            A Python object containing all attributes injested from
+            the YAML-formatted file; returned if return_obj is True
+            upon entry.
+
+        """
 
         # Define the YAML library loader type.
         YAMLLoader.add_implicit_resolver(
@@ -326,13 +400,17 @@ class YAML:
             if not is_yaml:
                 yaml_dict_concat[attr_key] = attr_value
 
+        # Define the Python data type to be returned; proceed
+        # accordingly.
         if return_obj:
 
             yaml_return = self.__yaml_obj__(attr_dict=yaml_dict_concat)
 
-            print(yaml_return)
+        if not return_obj:
 
-        quit()
+            yaml_return = yaml_dict_concat
+
+        return yaml_return
 
     def read_yaml(self, yaml_file: str, return_obj: bool = False) -> Union[dict, object]:
         """

--- a/confs/yaml_interface.py
+++ b/confs/yaml_interface.py
@@ -267,6 +267,9 @@ class YAML:
         # Write the resulting composite Python dictionary to
         # YAML-formatted file to contain the concatenated attributes.
 
+        print(yaml_dict_concat)
+        quit()
+
         return yaml_dict_concat
 
         # self.write_yaml(yaml_file=yaml_file_out, in_dict=yaml_dict_concat)

--- a/confs/yaml_interface.py
+++ b/confs/yaml_interface.py
@@ -339,10 +339,8 @@ class YAML:
                 yaml_value = parser_interface.dict_key_value(
                     dict_in=yaml_dict, key=yaml_key, no_split=True)
 
-                print(yaml_value)
-
-            # print(self.concat_yaml(yaml_file_list=yaml_file_list,
-            #                       yaml_file_out=None, ignore_missing=True))
+            print(self.concat_yaml(yaml_file_list=yaml_file_list,
+                                   yaml_file_out=None, ignore_missing=True, fail_invalid=False))
 
         # print(yaml_dict)
 

--- a/confs/yaml_interface.py
+++ b/confs/yaml_interface.py
@@ -311,7 +311,7 @@ class YAML:
             if not is_yaml:
                 yaml_dict_concat[attr_key] = attr_value
 
-        print(yaml_dict_concat)
+        print(yaml_dict_concat['fetch'])
 
         quit()
 

--- a/confs/yaml_interface.py
+++ b/confs/yaml_interface.py
@@ -311,7 +311,11 @@ class YAML:
             if not is_yaml:
                 yaml_dict_concat[attr_key] = attr_value
 
-        print(yaml_dict_concat['fetch'])
+        for key in yaml_dict_concat['fetch']:
+            print(key, parser_interface.dict_key_value(
+                dict_in=yaml_dict_concat['fetch'], key=key, no_split=True))
+
+        # print(yaml_dict_concat['fetch'])
 
         quit()
 

--- a/confs/yaml_interface.py
+++ b/confs/yaml_interface.py
@@ -269,7 +269,7 @@ class YAML:
         self.write_yaml(yaml_file=yaml_file_out, in_dict=yaml_dict_concat)
 
     def read_yaml(
-        self, yaml_file: str, return_obj: bool = False
+            self, yaml_file: str, return_obj: bool = False, concat: bool = False,
     ) -> Union[dict, object]:
         """
         Description
@@ -317,7 +317,8 @@ class YAML:
         """
 
         # Define the YAML library loader type.
-        YAMLLoader.add_implicit_resolver("!ENV", YAMLLoader.envvar_matcher, None)
+        YAMLLoader.add_implicit_resolver(
+            "!ENV", YAMLLoader.envvar_matcher, None)
         YAMLLoader.add_constructor("!ENV", YAMLLoader.envvar_constructor)
 
         # Open and read the contents of the specified YAML-formatted
@@ -325,6 +326,9 @@ class YAML:
         with open(yaml_file, "r", encoding="utf-8") as stream:
             yaml_dict = yaml.load(stream, Loader=YAMLLoader)
 
+        print(yaml_dict)
+        quit()
+            
         # Define the Python data type to be returned; proceed
         # accordingly.
         yaml_return = None


### PR DESCRIPTION
This PR introduces a method to the YAML class within confs/yaml_interface.py.

This method reads a YAML-formatted file, checks whether YAML-formatted file paths are embedded, and creates/returns a Python object or dictionary containing the contents of the input YAML-formatted file as well as the expanded attributes of any embedded YAML-formatted file paths.
