### PR TITLE
Feature/yaml dump

### DIFF
--- a/confs/yaml_interface.py
+++ b/confs/yaml_interface.py
@@ -303,7 +303,54 @@ class YAML:
 
     def dict_to_yaml(self, yaml_dict: Dict, default_flow_style: bool = False,
                      indent: int = 4, level: str = None, nspace: int = 0) -> None:
-        """ """
+        """
+        Description
+        -----------
+
+        This method writes the contents of the Python diction provided
+        upon entry to a YAML-format in accordance with the keyword
+        arguments specified upon entry.
+
+        Parameters
+        ----------
+
+        yaml_dict: dict
+
+            A Python dictionary containing the attributes to be
+            written to a YAML-format.
+
+        Keywords
+        --------
+
+        default_flow_style: bool, optional
+
+            A Python boolean valued variable; if True upon entry, the
+            contents of the Python dictionary will not be serialized
+            when written to YAML-format; if False upon the entry, the
+            contents of the Python dictionary will be serialized in
+            block style.
+
+        indent: int, optional
+
+            A Python integer specifying the indent with for nest
+            YAML-formatted blocks.
+
+        level: str, optional
+
+            A Python string specifying the logger level to accompany
+            the contents of the YAML-formatted Python dictionary; if
+            NoneType upon entry, the contents will be written to
+            standard out; otherwise the specified (and supported)
+            level of the Logger object (see
+            utils/logger_interface.py).
+
+        nspace: int, optional
+
+            A Python integer specifying the total number of spaces to
+            be used when the Logger object level is used; this is only
+            implemented with the Logger interface is invoked.
+
+        """
 
         # Dump the contents of the Python dictionary and define a
         # local object.

--- a/confs/yaml_interface.py
+++ b/confs/yaml_interface.py
@@ -316,7 +316,7 @@ class YAML:
             # Dump the contents of the Python dictionary using the
             # imported Logger object.
             logger = parser_interface.object_getattr(
-                object_in=Logger, key=level, force=True, no_split=True)
+                object_in=Logger, key=level, force=True)
             logger(msg="TEST")
 
     def read_concat_yaml(

--- a/confs/yaml_interface.py
+++ b/confs/yaml_interface.py
@@ -313,17 +313,16 @@ class YAML:
         # Dump the contents of the Python dictionary to a YAML-format
         # in accordance with the parameters collected upon entry.
         if level is None:
-            pass
-            # sys.stdout.write(yaml_dump)
-            # sys.stdout.write(yaml.dump(yaml_dict, default_flow_style=default_flow_style,
-            #                           indent=indent))
+            sys.stdout.write(yaml_dump)
 
         if level is not None:
 
             # Dump the contents of the Python dictionary using the
             # imported Logger object.
             logger = parser_interface.object_getattr(
-                 object_in=Logger(), key=level, force=True)
+                object_in=Logger(), key=level,
+                force=True)
+            logger(yaml_dump)
 
     def read_concat_yaml(
         self, yaml_file: str, return_obj: bool = False
@@ -390,7 +389,7 @@ class YAML:
         # determine whether a given file is a YAML-formatted file and
         # whether the respective YAML-formatted file exists; proceed
         # acccordingly.
-        yaml_dict_concat={}
+        yaml_dict_concat = {}
         for attr_key in yaml_full_dict:
 
             # Collect the attribute corresponding to the respective

--- a/confs/yaml_interface.py
+++ b/confs/yaml_interface.py
@@ -316,7 +316,7 @@ class YAML:
             # Dump the contents of the Python dictionary using the
             # imported Logger object.
             logger = parser_interface.object_getattr(
-                object_in=Logger, key=level, force=True)
+                object_in=Logger(), key=level, force=True)
             logger(msg="TEST")
 
     def read_concat_yaml(

--- a/confs/yaml_interface.py
+++ b/confs/yaml_interface.py
@@ -302,7 +302,7 @@ class YAML:
         self.write_yaml(yaml_file=yaml_file_out, in_dict=yaml_dict_concat)
 
     def dict_to_yaml(self, yaml_dict: Dict, default_flow_style: bool = False,
-                     indent: int = 4, level: str = None) -> None:
+                     indent: int = 4, level: str = None, nspace: int = 0) -> None:
         """ """
 
         # Dump the contents of the Python dictionary and define a
@@ -322,7 +322,7 @@ class YAML:
             logger = parser_interface.object_getattr(
                 object_in=Logger(), key=level,
                 force=True)
-            logger(msg=("\n" + yaml_dump))
+            logger(msg=(nspace*"\n" + yaml_dump))
 
     def read_concat_yaml(
         self, yaml_file: str, return_obj: bool = False

--- a/confs/yaml_interface.py
+++ b/confs/yaml_interface.py
@@ -310,19 +310,19 @@ class YAML:
         yaml_dump = yaml.dump(yaml_dict, default_flow_style=default_flow_style,
                               indent=indent)
 
-           # Dump the contents of the Python dictionary to a YAML-format
-           # in accordance with the parameters collected upon entry.
-           if level is None:
-                sys.stdout.write(yaml_dump)
-                # sys.stdout.write(yaml.dump(yaml_dict, default_flow_style=default_flow_style,
-                #                           indent=indent))
+        # Dump the contents of the Python dictionary to a YAML-format
+        # in accordance with the parameters collected upon entry.
+        if level is None:
+            sys.stdout.write(yaml_dump)
+            # sys.stdout.write(yaml.dump(yaml_dict, default_flow_style=default_flow_style,
+            #                           indent=indent))
 
-            if level is not None:
+        if level is not None:
 
-                # Dump the contents of the Python dictionary using the
-                # imported Logger object.
-                logger = parser_interface.object_getattr(
-                    object_in=Logger(), key=level, force=True)
+            # Dump the contents of the Python dictionary using the
+            # imported Logger object.
+            logger = parser_interface.object_getattr(
+                object_in=Logger(), key=level, force=True)
 
     def read_concat_yaml(
         self, yaml_file: str, return_obj: bool = False
@@ -383,7 +383,7 @@ class YAML:
         # Open and read the contents of the specified YAML-formatted
         # file path.
         with open(yaml_file, "r", encoding="utf-8") as stream:
-            yaml_full_dict=yaml.load(stream, Loader=YAMLLoader)
+            yaml_full_dict = yaml.load(stream, Loader=YAMLLoader)
 
         # For each attribute within the parsed YAML-formatted file,
         # determine whether a given file is a YAML-formatted file and

--- a/confs/yaml_interface.py
+++ b/confs/yaml_interface.py
@@ -66,6 +66,7 @@ History
 
 import os
 import re
+import sys
 from typing import Dict, List, Union
 
 import yaml
@@ -306,8 +307,8 @@ class YAML:
 
         # Dump the contents of the Python dictionary to a YAML-format
         # in accordance with the parameters collected upon entry.
-        yaml.dump(yaml_dict, default_flow_style=default_flow_style,
-                  indent=indent)
+        sys.stdout.write(yaml.dump(yaml_dict, default_flow_style=default_flow_style,
+                                   indent=indent))
 
     def read_concat_yaml(
         self, yaml_file: str, return_obj: bool = False

--- a/confs/yaml_interface.py
+++ b/confs/yaml_interface.py
@@ -313,7 +313,8 @@ class YAML:
         # Dump the contents of the Python dictionary to a YAML-format
         # in accordance with the parameters collected upon entry.
         if level is None:
-            sys.stdout.write(yaml_dump)
+            pass
+            # sys.stdout.write(yaml_dump)
             # sys.stdout.write(yaml.dump(yaml_dict, default_flow_style=default_flow_style,
             #                           indent=indent))
 
@@ -322,7 +323,7 @@ class YAML:
             # Dump the contents of the Python dictionary using the
             # imported Logger object.
             logger = parser_interface.object_getattr(
-                object_in=Logger(), key=level, force=True)
+                 object_in=Logger(), key=level, force=True)
 
     def read_concat_yaml(
         self, yaml_file: str, return_obj: bool = False

--- a/confs/yaml_interface.py
+++ b/confs/yaml_interface.py
@@ -322,7 +322,7 @@ class YAML:
             logger = parser_interface.object_getattr(
                 object_in=Logger(), key=level,
                 force=True)
-            logger(yaml_dump)
+            logger(msg=("\n" + yaml_dump))
 
     def read_concat_yaml(
         self, yaml_file: str, return_obj: bool = False

--- a/confs/yaml_interface.py
+++ b/confs/yaml_interface.py
@@ -61,6 +61,7 @@ History
 
 # pylint: disable=broad-except
 # pylint: disable=too-many-ancestors
+# pylint: disable=too-many-arguments
 
 # ----
 
@@ -301,8 +302,14 @@ class YAML:
         # YAML-formatted file to contain the concatenated attributes.
         self.write_yaml(yaml_file=yaml_file_out, in_dict=yaml_dict_concat)
 
-    def dict_to_yaml(self, yaml_dict: Dict, default_flow_style: bool = False,
-                     indent: int = 4, level: str = None, nspace: int = 0) -> None:
+    def dict_to_yaml(
+        self,
+        yaml_dict: Dict,
+        default_flow_style: bool = False,
+        indent: int = 4,
+        level: str = None,
+        nspace: int = 0,
+    ) -> None:
         """
         Description
         -----------
@@ -354,8 +361,9 @@ class YAML:
 
         # Dump the contents of the Python dictionary and define a
         # local object.
-        yaml_dump = yaml.dump(yaml_dict, default_flow_style=default_flow_style,
-                              indent=indent)
+        yaml_dump = yaml.dump(
+            yaml_dict, default_flow_style=default_flow_style, indent=indent
+        )
 
         # Dump the contents of the Python dictionary to a YAML-format
         # in accordance with the parameters collected upon entry.
@@ -367,9 +375,9 @@ class YAML:
             # Dump the contents of the Python dictionary using the
             # imported Logger object.
             logger = parser_interface.object_getattr(
-                object_in=Logger(), key=level,
-                force=True)
-            logger(msg=(nspace*"\n" + yaml_dump))
+                object_in=Logger(), key=level, force=True
+            )
+            logger(msg=(nspace * "\n" + yaml_dump))
 
     def read_concat_yaml(
         self, yaml_file: str, return_obj: bool = False
@@ -423,8 +431,7 @@ class YAML:
         """
 
         # Define the YAML library loader type.
-        YAMLLoader.add_implicit_resolver(
-            "!ENV", YAMLLoader.envvar_matcher, None)
+        YAMLLoader.add_implicit_resolver("!ENV", YAMLLoader.envvar_matcher, None)
         YAMLLoader.add_constructor("!ENV", YAMLLoader.envvar_constructor)
 
         # Open and read the contents of the specified YAML-formatted
@@ -528,8 +535,7 @@ class YAML:
         """
 
         # Define the YAML library loader type.
-        YAMLLoader.add_implicit_resolver(
-            "!ENV", YAMLLoader.envvar_matcher, None)
+        YAMLLoader.add_implicit_resolver("!ENV", YAMLLoader.envvar_matcher, None)
         YAMLLoader.add_constructor("!ENV", YAMLLoader.envvar_constructor)
         YAMLLoader.add_constructor("!INC", YAMLLoader.include_constructor)
 

--- a/confs/yaml_interface.py
+++ b/confs/yaml_interface.py
@@ -300,6 +300,15 @@ class YAML:
         # YAML-formatted file to contain the concatenated attributes.
         self.write_yaml(yaml_file=yaml_file_out, in_dict=yaml_dict_concat)
 
+    def dict_to_yaml(self, yaml_dict: Dict, default_flow_style: bool = False,
+                     indent: int = 4) -> None:
+        """ """
+
+        # Dump the contents of the Python dictionary to a YAML-format
+        # in accordance with the parameters collected upon entry.
+        yaml.dump(yaml_dict, default_flow_style=default_flow_style,
+                  indent=indent)
+
     def read_concat_yaml(
         self, yaml_file: str, return_obj: bool = False
     ) -> Union[Dict, object]:
@@ -352,7 +361,8 @@ class YAML:
         """
 
         # Define the YAML library loader type.
-        YAMLLoader.add_implicit_resolver("!ENV", YAMLLoader.envvar_matcher, None)
+        YAMLLoader.add_implicit_resolver(
+            "!ENV", YAMLLoader.envvar_matcher, None)
         YAMLLoader.add_constructor("!ENV", YAMLLoader.envvar_constructor)
 
         # Open and read the contents of the specified YAML-formatted
@@ -456,7 +466,8 @@ class YAML:
         """
 
         # Define the YAML library loader type.
-        YAMLLoader.add_implicit_resolver("!ENV", YAMLLoader.envvar_matcher, None)
+        YAMLLoader.add_implicit_resolver(
+            "!ENV", YAMLLoader.envvar_matcher, None)
         YAMLLoader.add_constructor("!ENV", YAMLLoader.envvar_constructor)
         YAMLLoader.add_constructor("!INC", YAMLLoader.include_constructor)
 

--- a/confs/yaml_interface.py
+++ b/confs/yaml_interface.py
@@ -302,13 +302,22 @@ class YAML:
         self.write_yaml(yaml_file=yaml_file_out, in_dict=yaml_dict_concat)
 
     def dict_to_yaml(self, yaml_dict: Dict, default_flow_style: bool = False,
-                     indent: int = 4) -> None:
+                     indent: int = 4, level: str = None) -> None:
         """ """
 
         # Dump the contents of the Python dictionary to a YAML-format
         # in accordance with the parameters collected upon entry.
-        sys.stdout.write(yaml.dump(yaml_dict, default_flow_style=default_flow_style,
-                                   indent=indent))
+        if level is None:
+            sys.stdout.write(yaml.dump(yaml_dict, default_flow_style=default_flow_style,
+                                       indent=indent))
+
+        if level is not None:
+
+            # Dump the contents of the Python dictionary using the
+            # imported Logger object.
+            logger = parser_interface.object_getattr(
+                object_in=Logger, key=level, force=True, no_split=True)
+            logger(msg="TEST")
 
     def read_concat_yaml(
         self, yaml_file: str, return_obj: bool = False

--- a/confs/yaml_interface.py
+++ b/confs/yaml_interface.py
@@ -305,19 +305,24 @@ class YAML:
                      indent: int = 4, level: str = None) -> None:
         """ """
 
-        # Dump the contents of the Python dictionary to a YAML-format
-        # in accordance with the parameters collected upon entry.
-        if level is None:
-            sys.stdout.write(yaml.dump(yaml_dict, default_flow_style=default_flow_style,
-                                       indent=indent))
+        # Dump the contents of the Python dictionary and define a
+        # local object.
+        yaml_dump = yaml.dump(yaml_dict, default_flow_style=default_flow_style,
+                              indent=indent)
 
-        if level is not None:
+           # Dump the contents of the Python dictionary to a YAML-format
+           # in accordance with the parameters collected upon entry.
+           if level is None:
+                sys.stdout.write(yaml_dump)
+                # sys.stdout.write(yaml.dump(yaml_dict, default_flow_style=default_flow_style,
+                #                           indent=indent))
 
-            # Dump the contents of the Python dictionary using the
-            # imported Logger object.
-            logger = parser_interface.object_getattr(
-                object_in=Logger(), key=level, force=True)
-            logger(msg="TEST")
+            if level is not None:
+
+                # Dump the contents of the Python dictionary using the
+                # imported Logger object.
+                logger = parser_interface.object_getattr(
+                    object_in=Logger(), key=level, force=True)
 
     def read_concat_yaml(
         self, yaml_file: str, return_obj: bool = False
@@ -378,13 +383,13 @@ class YAML:
         # Open and read the contents of the specified YAML-formatted
         # file path.
         with open(yaml_file, "r", encoding="utf-8") as stream:
-            yaml_full_dict = yaml.load(stream, Loader=YAMLLoader)
+            yaml_full_dict=yaml.load(stream, Loader=YAMLLoader)
 
         # For each attribute within the parsed YAML-formatted file,
         # determine whether a given file is a YAML-formatted file and
         # whether the respective YAML-formatted file exists; proceed
         # acccordingly.
-        yaml_dict_concat = {}
+        yaml_dict_concat={}
         for attr_key in yaml_full_dict:
 
             # Collect the attribute corresponding to the respective


### PR DESCRIPTION
This PR addresses issue #109.

This PR includes a new method within the `confs/yaml_interface.py` `YAML` class that allows a user to write a Python dictionary as a YAML-format either to standard out or using the `utils/logger_interface.py` `Logger` object.