### PR TITLE
Bug/jinja2 exception for missing vars

### DIFF
--- a/.pycodestyle
+++ b/.pycodestyle
@@ -1,6 +1,6 @@
 [pycodestyle]
 count = False
-ignore = W291, E741, W503
+ignore = E203, W291, E741, W503
 max-line-length = 160
 statistics = True
 exclude = Experimental

--- a/confs/jinja2_interface.py
+++ b/confs/jinja2_interface.py
@@ -165,8 +165,8 @@ def _fail_missing_vars(tmpl_path: str, in_dict: Dict) -> None:
         # Initialize the variables.
         variables = []
 
-        start = "{{"
-        stop = "}}"
+        start_str = "{{"
+        stop_str = "}}"
 
         # Collect all data from the Jinja2-formatted file.
         with open(tmpl_path, "r", encoding="utf-8") as file:
@@ -175,16 +175,18 @@ def _fail_missing_vars(tmpl_path: str, in_dict: Dict) -> None:
         # Search for Jinja2-formatted template variables; proceed
         # accordingly; ignoring template variable with default values.
         for item in data:
-            if (start and stop in item) and ("or" not in item):
-                string = (
-                    item[item.find(start) + len(start) : item.rfind(stop)].rstrip()
-                ).lstrip()
+            if (start_str and stop_str in item) and ("or" not in item):
+
+                start = item.index(start_str)
+                stop = item.index(stop_str)
+
+                string = (item[start+len(start_str):stop].rstrip()).lstrip()
                 variables.append(string)
 
     # Build the list of attribute variables.
     compare_variables = []
     for item in list(in_dict):
-        compare_variables.append(item[0])
+        compare_variables.append(item)
 
     # Compare the respective variable lists and find unique (i.e.,
     # missing variables).
@@ -316,7 +318,8 @@ def _get_template_file_attrs(tmpl_path: str) -> Union[str, str]:
     """
 
     # Collect the Jinja2-formatted template file attributes.
-    (dirname, basename) = [os.path.dirname(tmpl_path), os.path.basename(tmpl_path)]
+    (dirname, basename) = [os.path.dirname(
+        tmpl_path), os.path.basename(tmpl_path)]
 
     return (dirname, basename)
 

--- a/confs/jinja2_interface.py
+++ b/confs/jinja2_interface.py
@@ -321,7 +321,7 @@ def _get_template_vars(tmpl_path: str) -> List:
     env = _get_env(tmpl_path=tmpl_path)
     tmpl = _get_template(tmpl_path=tmpl_path)
 
-    print(meta)
+    print(dir(meta))
 
     # Collect the templated variable names.
     variables = list(meta.find_undeclared_variables(env.parse(tmpl)))

--- a/confs/jinja2_interface.py
+++ b/confs/jinja2_interface.py
@@ -183,7 +183,7 @@ def _fail_missing_vars(tmpl_path: str, in_dict: Dict) -> None:
     # Build the list of attribute variables.
     compare_variables = []
     for item in list(in_dict):
-        compare_variables.append(item(0))
+        compare_variables.append(item[0])
 
     print(compare_variables)
     print(variables)

--- a/confs/jinja2_interface.py
+++ b/confs/jinja2_interface.py
@@ -188,6 +188,10 @@ def _fail_missing_vars(tmpl_path: str, in_dict: Dict) -> None:
     for item in list(in_dict):
         compare_variables.append(item)
 
+    print(compare_variables)
+    print(variables)
+    quit()
+
     # Compare the respective variable lists and find unique (i.e.,
     # missing variables).
     missing_vars = [

--- a/confs/jinja2_interface.py
+++ b/confs/jinja2_interface.py
@@ -321,14 +321,11 @@ def _get_template_vars(tmpl_path: str) -> List:
     env = _get_env(tmpl_path=tmpl_path)
     tmpl = _get_template(tmpl_path=tmpl_path)
 
-    print(tmpl.blocks)
-    quit()
-
     # Collect the templated variable names.
-    variables = list(meta.find_undeclared_variables(env.parse(tmpl)))
-
-    print(variables)
+    print(env.parse(tmpl))
     quit()
+
+    variables = list(meta.find_undeclared_variables(env.parse(tmpl)))
 
     return variables
 

--- a/confs/jinja2_interface.py
+++ b/confs/jinja2_interface.py
@@ -165,10 +165,10 @@ def _fail_missing_vars(tmpl_path: str, in_dict: Dict) -> None:
 
         for item in data:
             if ("{{" and "}}" in item) and ("or" not in item):
-                string = re.search("{{ .* }}", item)
+                string = (re.search("{{ .* }}", item)).group(1)
                 print(string)
 
-    print(variables)
+    # print(variables)
     quit()
 
     missing_vars = [

--- a/confs/jinja2_interface.py
+++ b/confs/jinja2_interface.py
@@ -321,7 +321,8 @@ def _get_template_vars(tmpl_path: str) -> List:
     env = _get_env(tmpl_path=tmpl_path)
     tmpl = _get_template(tmpl_path=tmpl_path)
 
-    print(meta.nodes)
+    print(tmpl.blocks)
+    quit()
 
     # Collect the templated variable names.
     variables = list(meta.find_undeclared_variables(env.parse(tmpl)))

--- a/confs/jinja2_interface.py
+++ b/confs/jinja2_interface.py
@@ -165,7 +165,7 @@ def _fail_missing_vars(tmpl_path: str, in_dict: Dict) -> None:
 
         for item in data:
             if ("{{" and "}}" in item) and ("or" not in item):
-                string = re.search("{{ * }}", item)
+                string = re.search("{{ .* }}", item)
                 print(string)
 
     print(variables)

--- a/confs/jinja2_interface.py
+++ b/confs/jinja2_interface.py
@@ -57,7 +57,7 @@ Functions
         This function collects the template variable names from a
         Jinja2-formatted template file.
 
-    write_from_template(tmpl_path, jinja2_file, in_dict,
+    write_from_template(tmpl_path, output_file, in_dict,
                         fail_missing=False)
 
         This function writes a Jinja2-formatted file established from
@@ -155,6 +155,9 @@ def _fail_missing_vars(tmpl_path: str, in_dict: Dict) -> None:
     missing_vars = [
         variable for variable in variables if variable not in list(in_dict.keys())
     ]
+
+    print(missing_vars)
+    quit()
 
     # If Jinja2-formatted template file variables have not been
     # defined, proceed accordingly.
@@ -328,7 +331,7 @@ def _get_template_vars(tmpl_path: str) -> List:
 
 
 def write_from_template(
-    tmpl_path: str, jinja2_file: str, in_dict: Dict, fail_missing: bool = False
+    tmpl_path: str, output_file: str, in_dict: Dict, fail_missing: bool = False
 ) -> None:
     """
     Description
@@ -345,7 +348,7 @@ def write_from_template(
         A Python string defining the path to the Jinja2-formatted
         template file.
 
-    jinja2_file: str
+    output_file: str
 
         A Python string containing the full-path to the
         Jinja2-formatted file to be written.
@@ -385,12 +388,12 @@ def write_from_template(
     try:
         tmpl = _get_template(tmpl_path=tmpl_path)
 
-        with open(jinja2_file, "w", encoding="utf-8") as file:
+        with open(output_file, "w", encoding="utf-8") as file:
             file.write(tmpl.render(in_dict))
 
     except Exception as errmsg:
         msg = (
-            f"Rendering Jinja2-formatted file {jinja2_file} failed with "
+            f"Rendering Jinja2-formatted file {output_file} failed with "
             f"error {errmsg}. Aborting!!!"
         )
         raise Jinja2InterfaceError(msg=msg)

--- a/confs/jinja2_interface.py
+++ b/confs/jinja2_interface.py
@@ -322,7 +322,7 @@ def _get_template_vars(tmpl_path: str) -> List:
     tmpl = _get_template(tmpl_path=tmpl_path)
 
     # Collect the templated variable names.
-    print(env.parse(tmpl))
+    print(list(env.parse(tmpl)))
     quit()
 
     variables = list(meta.find_undeclared_variables(env.parse(tmpl)))

--- a/confs/jinja2_interface.py
+++ b/confs/jinja2_interface.py
@@ -164,7 +164,7 @@ def _fail_missing_vars(tmpl_path: str, in_dict: Dict) -> None:
             data = file.read().split('\n')
 
         for item in data:
-            if "{{" and "}}" in item:
+            if ("{{" and "}}" in item) and ("or" not in item):
                 print(item)
 
     print(variables)

--- a/confs/jinja2_interface.py
+++ b/confs/jinja2_interface.py
@@ -161,7 +161,7 @@ def _fail_missing_vars(tmpl_path: str, in_dict: Dict) -> None:
     if len(variables) == 0:
         variables = ()
         with open(tmpl_path, "r", encoding="utf-8") as file:
-            data = file.read().rsplit()
+            data = file.read().split('\n')
 
         for item in data:
             if "{{" and "}}" in item:

--- a/confs/jinja2_interface.py
+++ b/confs/jinja2_interface.py
@@ -161,9 +161,11 @@ def _fail_missing_vars(tmpl_path: str, in_dict: Dict) -> None:
     if len(variables) == 0:
         variables = ()
         with open(tmpl_path, "r", encoding="utf-8") as file:
-            data = file.read().split('\n')
+            data = file.read().rsplit()
 
-        print(data)
+        for item in data:
+            if "{{" and "}}" in item:
+                print(item)
 
     print(variables)
     quit()

--- a/confs/jinja2_interface.py
+++ b/confs/jinja2_interface.py
@@ -149,11 +149,14 @@ def _fail_missing_vars(tmpl_path: str, in_dict: Dict) -> None:
 
     """
 
+    # Check that the Python dictionary is not empty; proceed
+    # accordingly.
+    if not in_dict:
+        msg = "The Python dictionary provided upon entry is empty. Aborting!!!"
+        raise Jinja2InterfaceError(msg=msg)
+
     # Collect the variables within the Jinja2-formatted template file.
     variables = _get_template_vars(tmpl_path=tmpl_path)
-
-    print(variables)
-    quit()
 
     missing_vars = [
         variable for variable in variables if variable not in list(in_dict.keys())
@@ -322,9 +325,6 @@ def _get_template_vars(tmpl_path: str) -> List:
     tmpl = _get_template(tmpl_path=tmpl_path)
 
     # Collect the templated variable names.
-    print((env.undefined()))
-    quit()
-
     variables = list(meta.find_undeclared_variables(env.parse(tmpl)))
 
     return variables

--- a/confs/jinja2_interface.py
+++ b/confs/jinja2_interface.py
@@ -166,7 +166,7 @@ def _fail_missing_vars(tmpl_path: str, in_dict: Dict) -> None:
         for item in data:
             if ("{{" and "}}" in item) and ("or" not in item):
                 string = re.search("{{ .* }}", item)
-                print(string.match)
+                print(dir(string))
 
     # print(variables)
     quit()

--- a/confs/jinja2_interface.py
+++ b/confs/jinja2_interface.py
@@ -186,11 +186,10 @@ def _fail_missing_vars(tmpl_path: str, in_dict: Dict) -> None:
     # Build the list of attribute variables.
     compare_variables = []
     for item in list(in_dict):
-        compare_variables.append(item)
-
-    print(compare_variables)
-    print(variables)
-    quit()
+        if isinstance(item, tuple):
+            compare_variables.append(item[0])
+        else:
+            compare_variables.append(item)
 
     # Compare the respective variable lists and find unique (i.e.,
     # missing variables).

--- a/confs/jinja2_interface.py
+++ b/confs/jinja2_interface.py
@@ -159,7 +159,7 @@ def _fail_missing_vars(tmpl_path: str, in_dict: Dict) -> None:
     # Collect the variables within the Jinja2-formatted template file.
     variables = _get_template_vars(tmpl_path=tmpl_path)
     if len(variables) == 0:
-        variables = ()
+        variables = []
 
         start = "{{"
         stop = "}}"

--- a/confs/jinja2_interface.py
+++ b/confs/jinja2_interface.py
@@ -180,6 +180,10 @@ def _fail_missing_vars(tmpl_path: str, in_dict: Dict) -> None:
                     item[item.find(start) + len(start): item.rfind(stop)].rstrip()).lstrip()
                 variables.append(string)
 
+    print(list(in_dict))
+    print(variables)
+    quit()
+
     # Compare the respective variable lists and find unique (i.e.,
     # missing variables).
     missing_vars = [

--- a/confs/jinja2_interface.py
+++ b/confs/jinja2_interface.py
@@ -165,7 +165,7 @@ def _fail_missing_vars(tmpl_path: str, in_dict: Dict) -> None:
 
         for item in data:
             if ("{{" and "}}" in item) and ("or" not in item):
-                string = item.split()
+                string = item.split("{{" and "}}")
                 print(string)
 
     print(variables)

--- a/confs/jinja2_interface.py
+++ b/confs/jinja2_interface.py
@@ -166,7 +166,7 @@ def _fail_missing_vars(tmpl_path: str, in_dict: Dict) -> None:
         for item in data:
             if ("{{" and "}}" in item) and ("or" not in item):
                 #string = re.search("{{ .* }}", item)
-                string = item[item.find("{{") + len(2):item.rfind("}}")]
+                string = item[item.find("{{") + len("{{"):item.rfind("}}")]
                 print(string)
 
     # print(variables)

--- a/confs/jinja2_interface.py
+++ b/confs/jinja2_interface.py
@@ -180,7 +180,7 @@ def _fail_missing_vars(tmpl_path: str, in_dict: Dict) -> None:
                     item[item.find(start) + len(start): item.rfind(stop)].rstrip()).lstrip()
                 variables.append(string)
 
-    print(list(in_dict))
+    print(list(in_dict)[:](0))
     print(variables)
     quit()
 

--- a/confs/jinja2_interface.py
+++ b/confs/jinja2_interface.py
@@ -166,7 +166,7 @@ def _fail_missing_vars(tmpl_path: str, in_dict: Dict) -> None:
         for item in data:
             if ("{{" and "}}" in item) and ("or" not in item):
                 string = re.search("{{ .* }}", item)
-                print(string)
+                print(string.match)
 
     # print(variables)
     quit()

--- a/confs/jinja2_interface.py
+++ b/confs/jinja2_interface.py
@@ -165,7 +165,7 @@ def _fail_missing_vars(tmpl_path: str, in_dict: Dict) -> None:
 
         for item in data:
             if ("{{" and "}}" in item) and ("or" not in item):
-                string = (re.search("{{ .* }}", item)).group(1)
+                string = re.search("{{ .* }}", item)
                 print(string)
 
     # print(variables)

--- a/confs/jinja2_interface.py
+++ b/confs/jinja2_interface.py
@@ -322,7 +322,7 @@ def _get_template_vars(tmpl_path: str) -> List:
     tmpl = _get_template(tmpl_path=tmpl_path)
 
     # Collect the templated variable names.
-    print(list(env.parse(tmpl)))
+    print(dir(env))
     quit()
 
     variables = list(meta.find_undeclared_variables(env.parse(tmpl)))

--- a/confs/jinja2_interface.py
+++ b/confs/jinja2_interface.py
@@ -152,12 +152,12 @@ def _fail_missing_vars(tmpl_path: str, in_dict: Dict) -> None:
     # Collect the variables within the Jinja2-formatted template file.
     variables = _get_template_vars(tmpl_path=tmpl_path)
 
+    print(variables)
+    quit()
+
     missing_vars = [
         variable for variable in variables if variable not in list(in_dict.keys())
     ]
-
-    print(missing_vars)
-    quit()
 
     # If Jinja2-formatted template file variables have not been
     # defined, proceed accordingly.

--- a/confs/jinja2_interface.py
+++ b/confs/jinja2_interface.py
@@ -177,7 +177,8 @@ def _fail_missing_vars(tmpl_path: str, in_dict: Dict) -> None:
         for item in data:
             if (start and stop in item) and ("or" not in item):
                 string = (
-                    item[item.find(start) + len(start): item.rfind(stop)].rstrip()).lstrip()
+                    item[item.find(start) + len(start) : item.rfind(stop)].rstrip()
+                ).lstrip()
                 variables.append(string)
 
     # Build the list of attribute variables.
@@ -315,8 +316,7 @@ def _get_template_file_attrs(tmpl_path: str) -> Union[str, str]:
     """
 
     # Collect the Jinja2-formatted template file attributes.
-    (dirname, basename) = [os.path.dirname(
-        tmpl_path), os.path.basename(tmpl_path)]
+    (dirname, basename) = [os.path.dirname(tmpl_path), os.path.basename(tmpl_path)]
 
     return (dirname, basename)
 

--- a/confs/jinja2_interface.py
+++ b/confs/jinja2_interface.py
@@ -185,14 +185,10 @@ def _fail_missing_vars(tmpl_path: str, in_dict: Dict) -> None:
     for item in list(in_dict):
         compare_variables.append(item[0])
 
-    print(compare_variables)
-    print(variables)
-    quit()
-
     # Compare the respective variable lists and find unique (i.e.,
     # missing variables).
     missing_vars = [
-        variable for variable in variables if variable not in list(in_dict)
+        variable for variable in variables if variable not in compare_variables
     ]
 
     # If Jinja2-formatted template file variables have not been

--- a/confs/jinja2_interface.py
+++ b/confs/jinja2_interface.py
@@ -324,6 +324,9 @@ def _get_template_vars(tmpl_path: str) -> List:
     # Collect the templated variable names.
     variables = list(meta.find_undeclared_variables(env.parse(tmpl)))
 
+    print(variables)
+    quit()
+
     return variables
 
 

--- a/confs/jinja2_interface.py
+++ b/confs/jinja2_interface.py
@@ -180,7 +180,12 @@ def _fail_missing_vars(tmpl_path: str, in_dict: Dict) -> None:
                     item[item.find(start) + len(start): item.rfind(stop)].rstrip()).lstrip()
                 variables.append(string)
 
-    print(list(in_dict)[:](0))
+    # Build the list of attribute variables.
+    compare_variables = []
+    for item in list(in_dict):
+        compare_variables.append(item(0))
+
+    print(compare_variables)
     print(variables)
     quit()
 

--- a/confs/jinja2_interface.py
+++ b/confs/jinja2_interface.py
@@ -165,7 +165,7 @@ def _fail_missing_vars(tmpl_path: str, in_dict: Dict) -> None:
 
         for item in data:
             if ("{{" and "}}" in item) and ("or" not in item):
-                string = item.split("{{" and "}}")
+                string = re.search("{{ * }}", item)
                 print(string)
 
     print(variables)

--- a/confs/jinja2_interface.py
+++ b/confs/jinja2_interface.py
@@ -165,7 +165,8 @@ def _fail_missing_vars(tmpl_path: str, in_dict: Dict) -> None:
 
         for item in data:
             if ("{{" and "}}" in item) and ("or" not in item):
-                print(item)
+                string = item.split()
+                print(string)
 
     print(variables)
     quit()

--- a/confs/jinja2_interface.py
+++ b/confs/jinja2_interface.py
@@ -321,7 +321,7 @@ def _get_template_vars(tmpl_path: str) -> List:
     env = _get_env(tmpl_path=tmpl_path)
     tmpl = _get_template(tmpl_path=tmpl_path)
 
-    print(dir(meta))
+    print(meta.nodes)
 
     # Collect the templated variable names.
     variables = list(meta.find_undeclared_variables(env.parse(tmpl)))

--- a/confs/jinja2_interface.py
+++ b/confs/jinja2_interface.py
@@ -166,7 +166,7 @@ def _fail_missing_vars(tmpl_path: str, in_dict: Dict) -> None:
         for item in data:
             if ("{{" and "}}" in item) and ("or" not in item):
                 string = re.search("{{ .* }}", item)
-                print(dir(string))
+                print(string.groups())
 
     # print(variables)
     quit()

--- a/confs/jinja2_interface.py
+++ b/confs/jinja2_interface.py
@@ -321,6 +321,8 @@ def _get_template_vars(tmpl_path: str) -> List:
     env = _get_env(tmpl_path=tmpl_path)
     tmpl = _get_template(tmpl_path=tmpl_path)
 
+    print(meta)
+
     # Collect the templated variable names.
     variables = list(meta.find_undeclared_variables(env.parse(tmpl)))
 

--- a/confs/jinja2_interface.py
+++ b/confs/jinja2_interface.py
@@ -322,7 +322,7 @@ def _get_template_vars(tmpl_path: str) -> List:
     tmpl = _get_template(tmpl_path=tmpl_path)
 
     # Collect the templated variable names.
-    print(dir(env))
+    print((env.undefined()))
     quit()
 
     variables = list(meta.find_undeclared_variables(env.parse(tmpl)))

--- a/confs/jinja2_interface.py
+++ b/confs/jinja2_interface.py
@@ -169,11 +169,9 @@ def _fail_missing_vars(tmpl_path: str, in_dict: Dict) -> None:
 
         for item in data:
             if (start and stop in item) and ("or" not in item):
-                string = (item[item.find(start) + len(start):item.rfind(stop)].rstrip()).lstrip()
-                print(string)
-
-    # print(variables)
-    quit()
+                string = (item[item.find(start) +
+                               len(start):item.rfind(stop)].rstrip()).lstrip()
+                variables.append(string)
 
     missing_vars = [
         variable for variable in variables if variable not in list(in_dict.keys())

--- a/confs/jinja2_interface.py
+++ b/confs/jinja2_interface.py
@@ -89,7 +89,6 @@ History
 # ----
 
 import os
-import re
 from typing import Dict, List, Union
 
 from jinja2 import Environment, FileSystemLoader, meta
@@ -158,21 +157,31 @@ def _fail_missing_vars(tmpl_path: str, in_dict: Dict) -> None:
 
     # Collect the variables within the Jinja2-formatted template file.
     variables = _get_template_vars(tmpl_path=tmpl_path)
+
+    # If variables are collected, check again by search for the
+    # Jinja2-formatted template variables; proceed accordingly.
     if len(variables) == 0:
+
+        # Initialize the variables.
         variables = []
 
         start = "{{"
         stop = "}}"
 
+        # Collect all data from the Jinja2-formatted file.
         with open(tmpl_path, "r", encoding="utf-8") as file:
             data = file.read().split('\n')
 
+        # Search for Jinja2-formatted template variables; proceed
+        # accordingly; ignoring template variable with default values.
         for item in data:
             if (start and stop in item) and ("or" not in item):
                 string = (item[item.find(start) +
                                len(start):item.rfind(stop)].rstrip()).lstrip()
                 variables.append(string)
 
+    # Compare the respective variable lists and find unique (i.e.,
+    # missing variables).
     missing_vars = [
         variable for variable in variables if variable not in list(in_dict.keys())
     ]

--- a/confs/jinja2_interface.py
+++ b/confs/jinja2_interface.py
@@ -170,14 +170,15 @@ def _fail_missing_vars(tmpl_path: str, in_dict: Dict) -> None:
 
         # Collect all data from the Jinja2-formatted file.
         with open(tmpl_path, "r", encoding="utf-8") as file:
-            data = file.read().split('\n')
+            data = file.read().split("\n")
 
         # Search for Jinja2-formatted template variables; proceed
         # accordingly; ignoring template variable with default values.
         for item in data:
             if (start and stop in item) and ("or" not in item):
-                string = (item[item.find(start) +
-                               len(start):item.rfind(stop)].rstrip()).lstrip()
+                string = (
+                    item[item.find(start) + len(start) : item.rfind(stop)].rstrip()
+                ).lstrip()
                 variables.append(string)
 
     # Compare the respective variable lists and find unique (i.e.,
@@ -310,8 +311,7 @@ def _get_template_file_attrs(tmpl_path: str) -> Union[str, str]:
     """
 
     # Collect the Jinja2-formatted template file attributes.
-    (dirname, basename) = [os.path.dirname(
-        tmpl_path), os.path.basename(tmpl_path)]
+    (dirname, basename) = [os.path.dirname(tmpl_path), os.path.basename(tmpl_path)]
 
     return (dirname, basename)
 

--- a/confs/jinja2_interface.py
+++ b/confs/jinja2_interface.py
@@ -159,7 +159,7 @@ def _fail_missing_vars(tmpl_path: str, in_dict: Dict) -> None:
     # Collect the variables within the Jinja2-formatted template file.
     variables = _get_template_vars(tmpl_path=tmpl_path)
     if len(variables) == 0:
-        variables = re.findall("{{ .*? }}")
+        variables = re.findall("{{ .*? }}", None)
 
     print(variables)
     quit()

--- a/confs/jinja2_interface.py
+++ b/confs/jinja2_interface.py
@@ -160,13 +160,16 @@ def _fail_missing_vars(tmpl_path: str, in_dict: Dict) -> None:
     variables = _get_template_vars(tmpl_path=tmpl_path)
     if len(variables) == 0:
         variables = ()
+
+        start = "{{"
+        stop = "}}"
+
         with open(tmpl_path, "r", encoding="utf-8") as file:
             data = file.read().split('\n')
 
         for item in data:
-            if ("{{" and "}}" in item) and ("or" not in item):
-                #string = re.search("{{ .* }}", item)
-                string = item[item.find("{{") + len("{{"):item.rfind("}}")]
+            if (start and stop in item) and ("or" not in item):
+                string = (item[item.find(start) + len(start):item.rfind(stop)].rstrip()).lstrip()
                 print(string)
 
     # print(variables)

--- a/confs/jinja2_interface.py
+++ b/confs/jinja2_interface.py
@@ -177,10 +177,15 @@ def _fail_missing_vars(tmpl_path: str, in_dict: Dict) -> None:
         for item in data:
             if (start and stop in item) and ("or" not in item):
                 string = (
-                    item[item.find(start) + len(start) : item.rfind(stop)].rstrip()
+                    item[item.find(start) + len(start): item.rfind(stop)].rstrip()
                 ).lstrip()
                 variables.append(string)
 
+
+    print(variables)
+    print(in_dict)
+    quit()
+                
     # Compare the respective variable lists and find unique (i.e.,
     # missing variables).
     missing_vars = [

--- a/confs/jinja2_interface.py
+++ b/confs/jinja2_interface.py
@@ -177,19 +177,13 @@ def _fail_missing_vars(tmpl_path: str, in_dict: Dict) -> None:
         for item in data:
             if (start and stop in item) and ("or" not in item):
                 string = (
-                    item[item.find(start) + len(start): item.rfind(stop)].rstrip()
-                ).lstrip()
+                    item[item.find(start) + len(start): item.rfind(stop)].rstrip()).lstrip()
                 variables.append(string)
 
-
-    print(variables)
-    print(in_dict)
-    quit()
-                
     # Compare the respective variable lists and find unique (i.e.,
     # missing variables).
     missing_vars = [
-        variable for variable in variables if variable not in list(in_dict.keys())
+        variable for variable in variables if variable not in list(in_dict)
     ]
 
     # If Jinja2-formatted template file variables have not been
@@ -316,7 +310,8 @@ def _get_template_file_attrs(tmpl_path: str) -> Union[str, str]:
     """
 
     # Collect the Jinja2-formatted template file attributes.
-    (dirname, basename) = [os.path.dirname(tmpl_path), os.path.basename(tmpl_path)]
+    (dirname, basename) = [os.path.dirname(
+        tmpl_path), os.path.basename(tmpl_path)]
 
     return (dirname, basename)
 

--- a/confs/jinja2_interface.py
+++ b/confs/jinja2_interface.py
@@ -159,7 +159,11 @@ def _fail_missing_vars(tmpl_path: str, in_dict: Dict) -> None:
     # Collect the variables within the Jinja2-formatted template file.
     variables = _get_template_vars(tmpl_path=tmpl_path)
     if len(variables) == 0:
-        variables = re.findall("", "{{ }}")
+        variables = ()
+        with open(tmpl_path, "r", encoding="utf-8") as file:
+            data = file.read().split('\n')
+
+        print(data)
 
     print(variables)
     quit()

--- a/confs/jinja2_interface.py
+++ b/confs/jinja2_interface.py
@@ -89,6 +89,7 @@ History
 # ----
 
 import os
+import re
 from typing import Dict, List, Union
 
 from jinja2 import Environment, FileSystemLoader, meta
@@ -157,6 +158,11 @@ def _fail_missing_vars(tmpl_path: str, in_dict: Dict) -> None:
 
     # Collect the variables within the Jinja2-formatted template file.
     variables = _get_template_vars(tmpl_path=tmpl_path)
+    if len(variables) == 0:
+        variables = re.findall("{{ .*? }}")
+
+    print(variables)
+    quit()
 
     missing_vars = [
         variable for variable in variables if variable not in list(in_dict.keys())

--- a/confs/jinja2_interface.py
+++ b/confs/jinja2_interface.py
@@ -159,7 +159,7 @@ def _fail_missing_vars(tmpl_path: str, in_dict: Dict) -> None:
     # Collect the variables within the Jinja2-formatted template file.
     variables = _get_template_vars(tmpl_path=tmpl_path)
     if len(variables) == 0:
-        variables = re.findall("{{ .*? }}", None)
+        variables = re.findall("", "{{ }}")
 
     print(variables)
     quit()

--- a/confs/jinja2_interface.py
+++ b/confs/jinja2_interface.py
@@ -165,8 +165,9 @@ def _fail_missing_vars(tmpl_path: str, in_dict: Dict) -> None:
 
         for item in data:
             if ("{{" and "}}" in item) and ("or" not in item):
-                string = re.search("{{ .* }}", item)
-                print(string.groups())
+                #string = re.search("{{ .* }}", item)
+                string = item[item.find("{{") + len(2):item.rfind("}}")]
+                print(string)
 
     # print(variables)
     quit()

--- a/confs/tests/test_jinja2_interface.py
+++ b/confs/tests/test_jinja2_interface.py
@@ -149,7 +149,7 @@ class TestJinja2Methods(TestCase):
         # template file.
         jinja2_interface.write_from_template(
             tmpl_path=self.jinja2_template,
-            jinja2_file=self.jinja2_file,
+            output_file=self.jinja2_file,
             in_dict=self.jinja2_test_dict,
             fail_missing=True,
         )


### PR DESCRIPTION
This PR fixes a bug in `confs/jinja2_interface.py` when attempting to find template variables which have not been defined/specified upon entry.