### PR TITLE
Feature/templating updates additions

### DIFF
--- a/confs/jinja2_interface.py
+++ b/confs/jinja2_interface.py
@@ -98,7 +98,11 @@ import os
 from typing import Dict, List, Tuple
 
 from jinja2 import Environment, FileSystemLoader, meta
+from confs.template_interface import TMPL_ITEM_LIST
 from utils.exceptions_interface import Jinja2InterfaceError
+
+from tools import fileio_interface
+
 from utils.logger_interface import Logger
 
 # ----
@@ -180,7 +184,7 @@ def _fail_missing_vars(tmpl_path: str, in_dict: Dict) -> None:
                 start = item.index(start_str)
                 stop = item.index(stop_str)
 
-                string = (item[start + len(start_str) : stop].rstrip()).lstrip()
+                string = (item[start + len(start_str): stop].rstrip()).lstrip()
                 variables.append(string)
 
     # Build the list of attribute variables.
@@ -321,7 +325,8 @@ def _get_template_file_attrs(tmpl_path: str) -> Tuple[str, str]:
     """
 
     # Collect the Jinja2-formatted template file attributes.
-    (dirname, basename) = [os.path.dirname(tmpl_path), os.path.basename(tmpl_path)]
+    (dirname, basename) = [os.path.dirname(
+        tmpl_path), os.path.basename(tmpl_path)]
 
     return (dirname, basename)
 
@@ -363,15 +368,29 @@ def _get_template_vars(tmpl_path: str) -> List:
 
     return variables
 
+# ----
+
+
+def _replace_tmplmarkers(tmpl_path: str) -> str:
+    """ """
+
+    virtfile = fileio_interface.virtual_file()
+
+    print(virtfile)
+
+    os.unlink()
+
+    quit()
+
 
 # ----
 
 
 def write_from_template(
-    tmpl_path: str, output_file: str, in_dict: Dict, fail_missing: bool = False
+        tmpl_path: str, output_file: str, in_dict: Dict, fail_missing: bool = False,
+        rpl_tmpl_mrks: False
 ) -> None:
-    """
-    Description
+    """Description
     -----------
 
     This function writes a Jinja2-formatted file established from a
@@ -406,6 +425,13 @@ def write_from_template(
         Jinja2-formatted file template variable key and value pairs
         (in_dict).
 
+    rpl_tmpl_mrks: bool, optional
+
+        A Python boolean valued variable specifying whether to replace
+        any pre-defined template markers (see
+        `confs/template_interface.py`, prior to populating the
+        Jinja2-formatted template.
+
     Raises
     ------
 
@@ -415,6 +441,9 @@ def write_from_template(
           Jinja2-formatted file.
 
     """
+
+    if rpl_tmpl_mrks:
+        tmpl_path = _replace_tmplmarkers(tmpl_path=tmpl_path)
 
     if fail_missing:
         _fail_missing_vars(tmpl_path=tmpl_path, in_dict=in_dict)

--- a/confs/jinja2_interface.py
+++ b/confs/jinja2_interface.py
@@ -388,9 +388,9 @@ def _replace_tmplmarkers(tmpl_path: str) -> str:
 
 def write_from_template(
         tmpl_path: str, output_file: str, in_dict: Dict, fail_missing: bool = False,
-        rpl_tmpl_mrks: False
-) -> None:
-    """Description
+        rpl_tmpl_mrks: False) -> None:
+    """
+    Description
     -----------
 
     This function writes a Jinja2-formatted file established from a

--- a/confs/jinja2_interface.py
+++ b/confs/jinja2_interface.py
@@ -443,6 +443,7 @@ def write_from_template(
     """
 
     if rpl_tmpl_mrks:
+        print('here')
         tmpl_path = _replace_tmplmarkers(tmpl_path=tmpl_path)
 
     if fail_missing:

--- a/confs/jinja2_interface.py
+++ b/confs/jinja2_interface.py
@@ -388,7 +388,7 @@ def _replace_tmplmarkers(tmpl_path: str) -> str:
 
 def write_from_template(
         tmpl_path: str, output_file: str, in_dict: Dict, fail_missing: bool = False,
-        rpl_tmpl_mrks: False) -> None:
+        rpl_tmpl_mrks: bool = False) -> None:
     """
     Description
     -----------

--- a/confs/jinja2_interface.py
+++ b/confs/jinja2_interface.py
@@ -372,16 +372,59 @@ def _get_template_vars(tmpl_path: str) -> List:
 
 
 def _replace_tmplmarkers(tmpl_path: str) -> str:
-    """ """
+    """Description
+    -----------
 
-    virtfile = fileio_interface.virtual_file()
+    This function replaces specified non-Jinja2-formatted template
+    string-values with the respective Jinja2-formatted template
+    indicators; the updated template file is written to a temporary
+    (e.g., virtual) file path and returned to the calling function;
+    the non-Jinja2-formatted template string-values are defined bu the
+    `confs/template_interface.py` module attribute `TMPL_ITEM_LIST`.
 
-    print(virtfile)
+    Parameters
+    ----------
 
-    os.unlink()
+    tmpl_path: str
 
-    quit()
+        A Python string defining the path to the template file
+        containing non-Jinja2-formatted template string-values.
 
+    Returns
+    -------
+
+    virtfile: str
+
+        A Python string defining the path to the temporary (i.e.,
+        virtual) file path containing the Jinja2-formatted template
+        defined from the attributes contained within `tmpl_path` upon
+        entry.
+
+    """
+
+    # Read the non-Jinja2-formatted template file.
+    with open(tmpl_path, "r", encoding="utf-8") as file:
+        inputs = file.read().split("\n")
+
+    # Parse the contents of the non-Jinja2-formatted template file;
+    # update any encountered non-Jinja2-formatted template
+    # string-values with the appropriate Jinja2-formatted template
+    # string-values.
+    virtfile = fileio_interface.virtual_file().name
+
+    with open(virtfile, "w", encoding="utf-8") as file:
+        for string in inputs:
+            for item in TMPL_ITEM_LIST:
+                tmplstr = item.split("%s")
+
+                if (tmplstr[0] in string) and (tmplstr[1] in string):
+                    string = string.replace(tmplstr[0].strip(), "{{ ")
+                    string = string.replace(tmplstr[1].strip(), " }}")
+                    break
+
+            file.write(f"{string}\n")
+
+    return virtfile
 
 # ----
 
@@ -443,7 +486,6 @@ def write_from_template(
     """
 
     if rpl_tmpl_mrks:
-        print('here')
         tmpl_path = _replace_tmplmarkers(tmpl_path=tmpl_path)
 
     if fail_missing:
@@ -464,6 +506,9 @@ def write_from_template(
             f"error {errmsg}. Aborting!!!"
         )
         raise Jinja2InterfaceError(msg=msg)
+
+    if rpl_tmpl_mrks:
+        os.unlink(tmpl_path)
 
 
 # ----

--- a/confs/template_interface.py
+++ b/confs/template_interface.py
@@ -60,7 +60,7 @@ __email__ = "henry.winterbottom@noaa.gov"
 
 # -----
 
-from typing import Any, Dict
+from typing import Dict
 
 from tools import parser_interface
 from utils.decorator_interface import privatemethod
@@ -69,8 +69,16 @@ from utils.logger_interface import Logger
 
 # -----
 
-TMPL_ITEM_LIST = ["[@%s]", "{@%s}", "{%%%s%%}", "{{%% %s %%}}", "<%s>",
-                  "{%% %s %%}", "{{ %s }}"]
+TMPL_ITEM_LIST = [
+    "@[%s]",
+    "[@%s]",
+    "{@%s}",
+    "{%%%s%%}",
+    "{{%% %s %%}}",
+    "<%s>",
+    "{%% %s %%}",
+    "{{ %s }}",
+]
 
 # ----
 
@@ -95,46 +103,6 @@ class Template:
 
         # Define the base-class attributes.
         self.logger = Logger()
-
-    @staticmethod
-    def f90_bool(value: Any) -> Any:
-        """
-        Description
-        -----------
-
-        This method will transform boolean type values to a FORTRAN 90
-        boolean format; if the variable `value` specified upon entry
-        is not of boolean format the value is return unaltered.
-
-        Parameters
-        ----------
-
-        value: Any
-
-            A Python variable to be evaluated as a boolean type value;
-            if a boolean type the corresponding value is returned as a
-            FORTRAN 90 boolean format.
-
-        Returns
-        -------
-
-        value: Any
-
-            An evaluated Python variable; if `value` was boolean type
-            upon entry the returned value is of FORTRAN 90 boolean
-            format; if not, the unaltered input value is returned.
-
-        """
-
-        # Check the type for the respective input value; proceed
-        # accordingly.
-        if isinstance(value, bool):
-            if value:
-                value = "T"
-            if not value:
-                value = "F"
-
-        return value
 
     def read_tmpl(self: object, tmpl_path: str) -> str:
         """
@@ -241,11 +209,10 @@ class Template:
                     # Update value accordingly.
                     if value is not None:
                         if f90_bool:
-                            value = self.f90_bool(value=value)
+                            value = parser_interface.f90_bool(value=value)
                         attr_value = value
 
-                        tmpl_str_out = tmpl_str_out.replace(
-                            check_str, str(attr_value))
+                        tmpl_str_out = tmpl_str_out.replace(check_str, str(attr_value))
 
                 except TypeError:
                     pass
@@ -269,7 +236,7 @@ class Template:
             f"{', '.join(tmpl_str_list)}."
         )
 
-        if (len(tmpl_str_list) > 0):
+        if len(tmpl_str_list) > 0:
             if fail_missing:
                 msg = msg + " Aborting!!!"
                 raise TemplateInterfaceError(msg=msg)

--- a/confs/tests/test_template_interface.py
+++ b/confs/tests/test_template_interface.py
@@ -112,7 +112,13 @@ class TestTemplateMethods(TestCase):
         )
 
         self.tmpl2_dict = OrderedDict(
-            {"EGGS": 2, "HAM": 1, "DINNER": "spam", "DESSERT": "Always!"}
+            {
+                "EGGS": 2,
+                "HAM": 1,
+                "JUST_HAM": True,
+                "DINNER": "spam",
+                "DESSERT": "Always!",
+            }
         )
 
         # Define the file paths required for the test method(s).
@@ -178,10 +184,10 @@ class TestTemplateMethods(TestCase):
                 attr_dict=self.tmpl2_dict,
                 tmpl_path=self.tmpl_path,
                 template_path=self.template_path,
-                f90_bool=False,
+                f90_bool=True,
                 fail_missing=True,
             )
-            assert False
+            assert True
 
         except TemplateInterfaceError:
             assert True

--- a/confs/yaml_interface.py
+++ b/confs/yaml_interface.py
@@ -78,8 +78,8 @@ from typing import Any, Dict, List, Union
 
 import yaml
 from tools import fileio_interface, parser_interface
-from utils.exceptions_interface import YAMLInterfaceError
 from utils.decorator_interface import privatemethod
+from utils.exceptions_interface import YAMLInterfaceError
 from utils.logger_interface import Logger
 from yaml import SafeLoader
 
@@ -436,8 +436,7 @@ class YAML:
         """
 
         # Define the YAML library loader type.
-        YAMLLoader.add_implicit_resolver(
-            "!ENV", YAMLLoader.envvar_matcher, None)
+        YAMLLoader.add_implicit_resolver("!ENV", YAMLLoader.envvar_matcher, None)
         YAMLLoader.add_constructor("!ENV", YAMLLoader.envvar_constructor)
 
         # Open and read the contents of the specified YAML-formatted
@@ -543,8 +542,7 @@ class YAML:
         """
 
         # Define the YAML library loader type.
-        YAMLLoader.add_implicit_resolver(
-            "!ENV", YAMLLoader.envvar_matcher, None)
+        YAMLLoader.add_implicit_resolver("!ENV", YAMLLoader.envvar_matcher, None)
         YAMLLoader.add_constructor("!ENV", YAMLLoader.envvar_constructor)
         YAMLLoader.add_constructor("!INC", YAMLLoader.include_constructor)
 

--- a/tools/parser_interface.py
+++ b/tools/parser_interface.py
@@ -74,6 +74,12 @@ Functions
         This function defines the environment variable corresponding
         to the supported specified value.
 
+    f90_bool(value)
+
+        This method will transform boolean type values to a FORTRAN 90
+        boolean format; if the variable `value` specified upon entry
+        is not of boolean format the value is returned unaltered.
+
     find_commonprefix(strings_list)
 
         This function returns the common prefix from a list of strings.
@@ -230,6 +236,7 @@ __all__ = [
     "dict_replace_value",
     "enviro_get",
     "enviro_set",
+    "f90_bool",
     "find_commonprefix",
     "handler",
     "list_get_type",
@@ -725,6 +732,49 @@ def enviro_set(envvar: str, value: Union[bool, float, int, str]) -> None:
 
     if not isinstance(value, list):
         os.environ[envvar] = value
+
+
+# ----
+
+
+def f90_bool(value: Any) -> Any:
+    """
+    Description
+    -----------
+
+    This method will transform boolean type values to a FORTRAN 90
+    boolean format; if the variable `value` specified upon entry is
+    not of boolean format the value is returned unaltered.
+
+    Parameters
+    ----------
+
+    value: Any
+
+        A Python variable to be evaluated as a boolean type value; if
+        a boolean type the corresponding value is returned as a
+        FORTRAN 90 boolean format.
+
+    Returns
+    -------
+
+    value: Any
+
+        An evaluated Python variable; if `value` was boolean type upon
+        entry the returned value is of FORTRAN 90 boolean format; if
+        not, the unaltered input value is returned.
+
+    """
+
+    # Check the type for the respective input value; proceed
+    # accordingly.
+    if isinstance(value, bool):
+        if value:
+            value = "T"
+        if not value:
+            value = "F"
+
+    return value
 
 
 # ----


### PR DESCRIPTION
This PR adds capabilities to replace non-Jinja2-formatted template markers for analogous Jinja2-formatted template markers.

An example use case is the variety of templated files that the UFS carries around. This addition enables the files to be converted, in memory, to a Jinja2-formatted template such that it than be rendered using the Jinja2 libraries. This reduces the bloatedness of the code base and should reduce the size of the respective code base.