### PR TITLE
Feature/jinja2 skip missing vars

### DIFF
--- a/confs/jinja2_interface.py
+++ b/confs/jinja2_interface.py
@@ -195,7 +195,7 @@ def _fail_missing_vars(tmpl_path: str, in_dict: Dict) -> None:
                 start = item.index(start_str)
                 stop = item.index(stop_str)
 
-                string = (item[start + len(start_str) : stop].rstrip()).lstrip()
+                string = (item[start + len(start_str): stop].rstrip()).lstrip()
                 variables.append(string)
 
     # Build the list of attribute variables.
@@ -336,7 +336,8 @@ def _get_template_file_attrs(tmpl_path: str) -> Tuple[str, str]:
     """
 
     # Collect the Jinja2-formatted template file attributes.
-    (dirname, basename) = [os.path.dirname(tmpl_path), os.path.basename(tmpl_path)]
+    (dirname, basename) = [os.path.dirname(
+        tmpl_path), os.path.basename(tmpl_path)]
 
     return (dirname, basename)
 
@@ -523,6 +524,9 @@ def write_from_template(
     # path.
     try:
         tmpl = _get_template(tmpl_path=tmpl_path)
+
+        print(tmpl)
+        quit()
 
         with open(output_file, "w", encoding="utf-8") as file:
             file.write(tmpl.render(in_dict, env=os.environ))

--- a/confs/jinja2_interface.py
+++ b/confs/jinja2_interface.py
@@ -525,7 +525,7 @@ def write_from_template(
     try:
         tmpl = _get_template(tmpl_path=tmpl_path)
 
-        print(tmpl)
+        print(vars(tmpl))
         quit()
 
         with open(output_file, "w", encoding="utf-8") as file:

--- a/confs/jinja2_interface.py
+++ b/confs/jinja2_interface.py
@@ -374,11 +374,11 @@ def _get_template_vars(tmpl_path: str) -> List:
     env = _get_env(tmpl_path=tmpl_path)
     tmpl = _get_template(tmpl_path=tmpl_path)
 
-    print(list(meta).find_referenced_template(env.parse(tmpl))))
+    print(list(meta).find_referenced_template(env.parse(tmpl)))
     quit()
 
     # Collect the templated variable names.
-    variables=list(meta.find_undeclared_variables(env.parse(tmpl)))
+    variables = list(meta.find_undeclared_variables(env.parse(tmpl)))
 
     return variables
 

--- a/confs/jinja2_interface.py
+++ b/confs/jinja2_interface.py
@@ -381,9 +381,6 @@ def _get_template_vars(tmpl_path: str) -> List:
     # Collect the templated variable names.
     variables = list(meta.find_undeclared_variables(env.parse(tmpl)))
 
-    print(variables)
-    quit()
-
     return variables
 
 

--- a/confs/jinja2_interface.py
+++ b/confs/jinja2_interface.py
@@ -374,6 +374,9 @@ def _get_template_vars(tmpl_path: str) -> List:
     env = _get_env(tmpl_path=tmpl_path)
     tmpl = _get_template(tmpl_path=tmpl_path)
 
+    print(dir(meta))
+    quit()
+
     # Collect the templated variable names.
     variables = list(meta.find_undeclared_variables(env.parse(tmpl)))
 

--- a/confs/jinja2_interface.py
+++ b/confs/jinja2_interface.py
@@ -167,7 +167,7 @@ def _fail_missing_vars(tmpl_path: str, in_dict: Dict) -> None:
     # Check that the Python dictionary is not empty; proceed
     # accordingly.
     if not in_dict:
-        msg = "The Python dictionary provided upon entry is empty. Aborting!!!"
+        msg = "The Python dictionary `in_dict` provided upon entry is empty. Aborting!!!"
         raise Jinja2InterfaceError(msg=msg)
 
     # Collect the variables within the Jinja2-formatted template file.
@@ -200,6 +200,7 @@ def _fail_missing_vars(tmpl_path: str, in_dict: Dict) -> None:
 
     # Build the list of attribute variables.
     compare_variables = []
+
     for item in list(in_dict):
         if isinstance(item, tuple):
             compare_variables.append(item[0])
@@ -211,6 +212,9 @@ def _fail_missing_vars(tmpl_path: str, in_dict: Dict) -> None:
     missing_vars = [
         variable for variable in variables if variable not in compare_variables
     ]
+
+    print(missing_vars)
+    quit()
 
     # If Jinja2-formatted template file variables have not been
     # defined, proceed accordingly.
@@ -515,8 +519,8 @@ def write_from_template(
     if rpl_tmpl_mrks:
         tmpl_path = _replace_tmplmarkers(tmpl_path=tmpl_path)
 
-    # if fail_missing:
-    #    _fail_missing_vars(tmpl_path=tmpl_path, in_dict=in_dict)
+    if fail_missing:
+        _fail_missing_vars(tmpl_path=tmpl_path, in_dict=in_dict)
 
     if f90_bool:
         for (key, value) in in_dict.items():

--- a/confs/jinja2_interface.py
+++ b/confs/jinja2_interface.py
@@ -525,7 +525,7 @@ def write_from_template(
     try:
         tmpl = _get_template(tmpl_path=tmpl_path)
 
-        print(vars(tmpl))
+        print(dir(tmpl))
         quit()
 
         with open(output_file, "w", encoding="utf-8") as file:

--- a/confs/jinja2_interface.py
+++ b/confs/jinja2_interface.py
@@ -374,11 +374,11 @@ def _get_template_vars(tmpl_path: str) -> List:
     env = _get_env(tmpl_path=tmpl_path)
     tmpl = _get_template(tmpl_path=tmpl_path)
 
-    print(list(meta).find_referenced_template(env.parse(tmpl)))
-    quit()
-
     # Collect the templated variable names.
     variables = list(meta.find_undeclared_variables(env.parse(tmpl)))
+
+    print(variables)
+    quit()
 
     return variables
 

--- a/confs/jinja2_interface.py
+++ b/confs/jinja2_interface.py
@@ -515,8 +515,8 @@ def write_from_template(
     if rpl_tmpl_mrks:
         tmpl_path = _replace_tmplmarkers(tmpl_path=tmpl_path)
 
-    if fail_missing:
-        _fail_missing_vars(tmpl_path=tmpl_path, in_dict=in_dict)
+    # if fail_missing:
+    #    _fail_missing_vars(tmpl_path=tmpl_path, in_dict=in_dict)
 
     if f90_bool:
         for (key, value) in in_dict.items():
@@ -527,9 +527,6 @@ def write_from_template(
     # path.
     try:
         tmpl = _get_template(tmpl_path=tmpl_path)
-
-        print(dir(tmpl))
-        quit()
 
         with open(output_file, "w", encoding="utf-8") as file:
             file.write(tmpl.render(in_dict, env=os.environ))

--- a/confs/jinja2_interface.py
+++ b/confs/jinja2_interface.py
@@ -374,11 +374,11 @@ def _get_template_vars(tmpl_path: str) -> List:
     env = _get_env(tmpl_path=tmpl_path)
     tmpl = _get_template(tmpl_path=tmpl_path)
 
-    print(dir(meta))
+    print(list(meta).find_referenced_template(env.parse(tmpl))))
     quit()
 
     # Collect the templated variable names.
-    variables = list(meta.find_undeclared_variables(env.parse(tmpl)))
+    variables=list(meta.find_undeclared_variables(env.parse(tmpl)))
 
     return variables
 


### PR DESCRIPTION
This PR adds support for skipping template variables that do not have a corresponding key and value pair.